### PR TITLE
feat: device name/description inline edit

### DIFF
--- a/frontend/src/pages/Devices/DeviceDetail.css
+++ b/frontend/src/pages/Devices/DeviceDetail.css
@@ -1,0 +1,43 @@
+.device-detail-title .ant-typography-edit {
+  margin-left: 12px;
+  color: #bfbfbf;
+  font-size: 16px;
+  border: none;
+  box-shadow: none;
+  outline: none;
+  transition: color 0.2s;
+}
+
+.device-detail-title .ant-typography-edit:hover {
+  color: #595959;
+}
+
+.device-detail-title .ant-typography-edit:focus,
+.device-detail-title .ant-typography-edit:active {
+  color: #bfbfbf;
+  border: none;
+  box-shadow: none;
+  outline: none;
+}
+
+.device-detail-desc .ant-typography-edit {
+  margin-left: 8px;
+  color: #bfbfbf;
+  font-size: 13px;
+  border: none;
+  box-shadow: none;
+  outline: none;
+  transition: color 0.2s;
+}
+
+.device-detail-desc .ant-typography-edit:hover {
+  color: #595959;
+}
+
+.device-detail-desc .ant-typography-edit:focus,
+.device-detail-desc .ant-typography-edit:active {
+  color: #bfbfbf;
+  border: none;
+  box-shadow: none;
+  outline: none;
+}

--- a/frontend/src/pages/Devices/DeviceDetail.tsx
+++ b/frontend/src/pages/Devices/DeviceDetail.tsx
@@ -1,5 +1,6 @@
-import { EditOutlined } from "@ant-design/icons";
+import { SettingOutlined } from "@ant-design/icons";
 import { Badge, Button, Card, Descriptions, Space, Table, Typography } from "antd";
+import "./DeviceDetail.css";
 import type { ColumnsType } from "antd/es/table";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -45,8 +46,25 @@ export default function DeviceDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [editModalOpen, setEditModalOpen] = useState(false);
-  const { currentDevice, loading, fetchDevice, clearCurrentDevice } =
+  const { currentDevice, loading, fetchDevice, clearCurrentDevice, updateDevice } =
     useDeviceStore();
+
+  const handleInlineUpdate = async (field: "name" | "description", value: string) => {
+    if (!currentDevice || !id) return;
+    const trimmed = value.trim();
+    if (field === "name" && !trimmed) return;
+    if (trimmed === (currentDevice[field] ?? "")) return;
+    const result = await updateDevice(id, {
+      name: currentDevice.name,
+      slave_id: currentDevice.slave_id,
+      port: currentDevice.port,
+      description: currentDevice.description,
+      [field]: trimmed || null,
+    });
+    if (result) {
+      fetchDevice(id);
+    }
+  };
 
   useEffect(() => {
     if (id) {
@@ -67,14 +85,24 @@ export default function DeviceDetail() {
       <Space style={{ marginBottom: 16 }}>
         <Button onClick={() => navigate("/devices")}>Back to List</Button>
         <Button
-          icon={<EditOutlined />}
+          icon={<SettingOutlined />}
           onClick={() => setEditModalOpen(true)}
         >
-          Edit
+          Edit Settings
         </Button>
       </Space>
 
-      <Typography.Title level={2}>{currentDevice?.name}</Typography.Title>
+      <Typography.Title
+        level={2}
+        className="device-detail-title"
+        editable={{
+          onChange: (value) => handleInlineUpdate("name", value),
+          triggerType: ["icon"],
+          tooltip: "Rename",
+        }}
+      >
+        {currentDevice?.name}
+      </Typography.Title>
 
       <Card style={{ marginBottom: 16 }}>
         <Descriptions column={2}>
@@ -91,7 +119,17 @@ export default function DeviceDetail() {
             <Badge status={statusConfig.status} text={statusConfig.text} />
           </Descriptions.Item>
           <Descriptions.Item label="Description" span={2}>
-            {currentDevice?.description ?? "\u2014"}
+            <Typography.Paragraph
+              className="device-detail-desc"
+              editable={{
+                onChange: (value) => handleInlineUpdate("description", value),
+                triggerType: ["icon"],
+                tooltip: "Edit description",
+              }}
+              style={{ marginBottom: 0 }}
+            >
+              {currentDevice?.description ?? ""}
+            </Typography.Paragraph>
           </Descriptions.Item>
         </Descriptions>
       </Card>

--- a/frontend/src/pages/Devices/EditDeviceModal.tsx
+++ b/frontend/src/pages/Devices/EditDeviceModal.tsx
@@ -1,4 +1,4 @@
-import { Form, Input, InputNumber, Modal, Tooltip } from "antd";
+import { Form, InputNumber, Modal, Tooltip } from "antd";
 import { useEffect } from "react";
 import type { DeviceSummary, UpdateDevice } from "../../types";
 import { useDeviceStore } from "../../stores/deviceStore";
@@ -11,16 +11,14 @@ interface EditDeviceModalProps {
 }
 
 export function EditDeviceModal({ open, device, onClose, onSuccess }: EditDeviceModalProps) {
-  const [form] = Form.useForm<UpdateDevice>();
+  const [form] = Form.useForm<Pick<UpdateDevice, "slave_id" | "port">>();
   const { updateDevice, loading } = useDeviceStore();
 
   useEffect(() => {
     if (open && device) {
       form.setFieldsValue({
-        name: device.name,
         slave_id: device.slave_id,
         port: device.port,
-        description: device.description,
       });
     }
   }, [open, device, form]);
@@ -30,7 +28,11 @@ export function EditDeviceModal({ open, device, onClose, onSuccess }: EditDevice
   const handleSubmit = async () => {
     if (!device) return;
     const values = await form.validateFields();
-    const result = await updateDevice(device.id, values);
+    const result = await updateDevice(device.id, {
+      name: device.name,
+      description: device.description,
+      ...values,
+    });
     if (result) {
       onSuccess();
       onClose();
@@ -39,7 +41,7 @@ export function EditDeviceModal({ open, device, onClose, onSuccess }: EditDevice
 
   return (
     <Modal
-      title="Edit Device"
+      title="Edit Device Settings"
       open={open}
       onOk={handleSubmit}
       onCancel={onClose}
@@ -47,13 +49,6 @@ export function EditDeviceModal({ open, device, onClose, onSuccess }: EditDevice
       destroyOnClose
     >
       <Form form={form} layout="vertical">
-        <Form.Item
-          name="name"
-          label="Device Name"
-          rules={[{ required: true, message: "Please enter device name" }]}
-        >
-          <Input />
-        </Form.Item>
         <Tooltip title={isRunning ? "Stop the device before changing Slave ID" : undefined}>
           <Form.Item
             name="slave_id"
@@ -72,9 +67,6 @@ export function EditDeviceModal({ open, device, onClose, onSuccess }: EditDevice
             <InputNumber min={1} max={65535} style={{ width: "100%" }} disabled={isRunning} />
           </Form.Item>
         </Tooltip>
-        <Form.Item name="description" label="Description">
-          <Input.TextArea rows={2} />
-        </Form.Item>
       </Form>
     </Modal>
   );


### PR DESCRIPTION
## Summary\n- Device Detail 頁面 name 和 description 改為 inline edit（點筆 icon 直接編輯）\n- EditDeviceModal 簡化為只編輯 slave_id 和 port（按鈕改為 Edit Settings）\n- Edit icon 樣式：淺灰色、hover 變深灰、無 focus 藍框\n\n## Test plan\n- [ ] 進入 Device Detail，點 name 旁筆 icon → 可編輯，Enter 儲存\n- [ ] 點 description 旁筆 icon → 可編輯，Enter 儲存\n- [ ] 點 Edit Settings → Modal 只顯示 Slave ID 和 Port\n- [ ] 編輯後 icon 不殘留藍色\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)