### PR TITLE
feat: live register values in Device Detail + Open in Monitor button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Auto-resume: backend now automatically resumes running devices on startup (registers in protocol adapters + restarts simulation engine)
+- Device Detail: register table now shows live values via WebSocket (replaces hard-coded null)
+- Device Detail: "Open in Monitor" button navigates to Monitor page with device auto-selected
+- Device Detail: Live/Disconnected connection status badge on Register Map card
+- Monitor: supports `?device=<id>` query param for auto-selecting a device on page load
 
 ### Changed
 - Monitor DeviceCard preview: defaults to total_power + total_energy instead of voltage_l1/l2

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,25 @@
 # Development Log
 
+## 2026-03-30 — Device Detail Live Values & Monitor Navigation (#19)
+
+### What was done
+- **Live register values in Device Detail**: Connected Device Detail page to the existing `ws/monitor` WebSocket. Register table now overlays real-time values from the monitor broadcast instead of showing `—` (null). When the device is not running, values remain `—`.
+- **"Open in Monitor" button**: Added a button on Device Detail that navigates to `/monitor?device=<id>`, auto-selecting the device in the Monitor page. Button is disabled when the device is not running.
+- **Connection status badge**: Register Map card title shows a `Live` / `Disconnected` badge when the device is running.
+- **Monitor auto-select via query param**: Monitor page reads `?device=` query param on mount, waits for WebSocket data to arrive, then auto-selects the matching device. Query param is cleared after use to avoid stale state.
+
+### Decisions
+- Reused the existing `useWebSocket` hook and `ws/monitor` endpoint — no backend changes needed
+- Used `useMemo` to merge live values into the register list (keyed by register name), keeping the original register metadata (address, data type, etc.) from the REST API
+- Used a `useRef` flag (`autoSelectApplied`) to ensure the query param auto-select fires only once, even if `devices` array updates multiple times
+- Disabled the "Open in Monitor" button for non-running devices since the monitor only shows running devices
+
+### Files changed
+- `frontend/src/pages/Devices/DeviceDetail.tsx` — WebSocket connection, live value overlay, Open in Monitor button
+- `frontend/src/pages/Monitor/index.tsx` — `?device=` query param auto-select logic
+
+---
+
 ## 2026-03-29 — Auto-resume & Monitor UX Improvements
 
 ### What was done

--- a/frontend/src/pages/Devices/DeviceDetail.tsx
+++ b/frontend/src/pages/Devices/DeviceDetail.tsx
@@ -1,14 +1,18 @@
-import { SettingOutlined } from "@ant-design/icons";
-import { Badge, Button, Card, Descriptions, Space, Table, Tag, Typography } from "antd";
+import { DashboardOutlined, SettingOutlined } from "@ant-design/icons";
+import { Badge, Button, Card, Descriptions, Space, Table, Tag, Tooltip, Typography } from "antd";
 import "./DeviceDetail.css";
 import type { ColumnsType } from "antd/es/table";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useWebSocket } from "../../hooks/useWebSocket";
 import type { DeviceSummary, RegisterValue } from "../../types";
+import type { MonitorUpdate, RegisterData } from "../../types/monitor";
 import { useDeviceStore } from "../../stores/deviceStore";
 import { EditDeviceModal } from "./EditDeviceModal";
 import { MqttPublishConfig } from "./MqttPublishConfig";
 import { ScenarioCard } from "./ScenarioCard";
+
+const WS_URL = `ws://${window.location.hostname}:8000/ws/monitor`;
 
 const STATUS_CONFIG: Record<string, { status: "success" | "default" | "error"; text: string }> = {
   running: { status: "success", text: "Running" },
@@ -49,8 +53,32 @@ export default function DeviceDetail() {
   const navigate = useNavigate();
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [mqttPublishing, setMqttPublishing] = useState(false);
+  const [liveRegisters, setLiveRegisters] = useState<RegisterData[]>([]);
   const { currentDevice, loading, fetchDevice, clearCurrentDevice, updateDevice } =
     useDeviceStore();
+
+  const onMessage = useCallback(
+    (data: unknown) => {
+      const update = data as MonitorUpdate;
+      if (update.type === "monitor_update" && id) {
+        const device = update.devices.find((d) => d.device_id === id);
+        setLiveRegisters(device?.registers ?? []);
+      }
+    },
+    [id],
+  );
+
+  const { connected } = useWebSocket({ url: WS_URL, onMessage });
+
+  const registersWithLiveValues = useMemo(() => {
+    if (!currentDevice?.registers) return [];
+    if (liveRegisters.length === 0) return currentDevice.registers;
+    const liveMap = new Map(liveRegisters.map((r) => [r.name, r.value]));
+    return currentDevice.registers.map((reg) => ({
+      ...reg,
+      value: liveMap.get(reg.name) ?? reg.value,
+    }));
+  }, [currentDevice?.registers, liveRegisters]);
 
   const handleInlineUpdate = async (field: "name" | "description", value: string) => {
     if (!currentDevice || !id) return;
@@ -93,6 +121,15 @@ export default function DeviceDetail() {
         >
           Edit Settings
         </Button>
+        <Tooltip title={currentDevice?.status !== "running" ? "Device is not running" : ""}>
+          <Button
+            icon={<DashboardOutlined />}
+            onClick={() => navigate(`/monitor?device=${id}`)}
+            disabled={currentDevice?.status !== "running"}
+          >
+            Open in Monitor
+          </Button>
+        </Tooltip>
       </Space>
 
       <Typography.Title
@@ -142,10 +179,22 @@ export default function DeviceDetail() {
         </Descriptions>
       </Card>
 
-      <Card title="Register Map">
+      <Card
+        title={
+          <Space>
+            Register Map
+            {currentDevice?.status === "running" && (
+              <Badge
+                status={connected ? "success" : "error"}
+                text={connected ? "Live" : "Disconnected"}
+              />
+            )}
+          </Space>
+        }
+      >
         <Table
           columns={registerColumns}
-          dataSource={currentDevice?.registers ?? []}
+          dataSource={registersWithLiveValues}
           rowKey="name"
           loading={loading}
           pagination={false}

--- a/frontend/src/pages/Monitor/index.tsx
+++ b/frontend/src/pages/Monitor/index.tsx
@@ -1,5 +1,6 @@
 import { Badge, Collapse, Space, Typography } from "antd";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useWebSocket } from "../../hooks/useWebSocket";
 import { useMonitorStore } from "../../stores/monitorStore";
 import type { MonitorUpdate } from "../../types";
@@ -10,6 +11,8 @@ import { EventLog } from "./EventLog";
 const WS_URL = `ws://${window.location.hostname}:8000/ws/monitor`;
 
 export default function MonitorPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const autoSelectApplied = useRef(false);
   const {
     devices,
     events,
@@ -18,6 +21,21 @@ export default function MonitorPage() {
     handleMonitorUpdate,
     selectDevice,
   } = useMonitorStore();
+
+  // Auto-select device from ?device= query param (once devices are loaded)
+  useEffect(() => {
+    const deviceParam = searchParams.get("device");
+    if (deviceParam && devices.length > 0 && !autoSelectApplied.current) {
+      const exists = devices.some((d) => d.device_id === deviceParam);
+      if (exists) {
+        selectDevice(deviceParam);
+      }
+      // Clear the query param so it doesn't persist on manual navigation
+      searchParams.delete("device");
+      setSearchParams(searchParams, { replace: true });
+      autoSelectApplied.current = true;
+    }
+  }, [searchParams, setSearchParams, devices, selectDevice]);
 
   const onMessage = useCallback(
     (data: unknown) => {


### PR DESCRIPTION
## Summary
- Device Detail register table now shows **live values via WebSocket** instead of null placeholders
- Added **"Open in Monitor"** button that navigates to Monitor page with device auto-selected
- Monitor page supports `?device=<id>` query param for deep-linking from Device Detail

Closes #19

## Changes
- `DeviceDetail.tsx`: connect to `ws/monitor`, overlay live register values, add Open in Monitor button + Live/Disconnected badge
- `Monitor/index.tsx`: read `?device=` query param and auto-select device on mount

## Test plan
- [ ] Start a device, open Device Detail — register values should update live (no more `—`)
- [ ] Stop the device — values should revert to `—`, "Open in Monitor" button disabled
- [ ] Click "Open in Monitor" on a running device — should navigate to `/monitor` with that device selected
- [ ] Directly visit `/monitor?device=<id>` — device should be auto-selected
- [ ] TypeScript check (`tsc --noEmit`) passes
- [ ] Production build (`vite build`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)