### PR TITLE
docs: mark Milestone 8.7 progress after PR #24 merge

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,33 @@
 # Development Log
 
+## 2026-04-09 — PR #24 merged (consolidation pass: VM hack + CI + docs drift + lint debt + stale test)
+
+PR #24 merged into `dev` (merge commit `83c91c6`) bundling five commits from the consolidation audit:
+
+1. `53ad096` chore: remove VirtualBox shared-folder workaround from frontend tooling
+2. `d545415` ci: restore GitHub Actions pipeline for backend lint/test and frontend build
+3. `b790c82` docs: close API reference drift by documenting 18 missing endpoints
+4. `11d9ae2` chore: fix 91 ruff lint errors accumulated while CI was disabled
+5. `b7f8a8b` test: update test_batch_create_with_prefix for new name format
+
+Net effect: 55 files changed, +875 / -145. CI is now green and runs on every push to `dev`/`main`. The "first real CI run after restore" was red as expected (91 lint errors + 1 stale test); both were cleaned up in the same PR so the dev branch lands green.
+
+Issue #21 (Cloudflare Pages build config) was closed in parallel — fixed via a Cloudflare Dashboard setting change (Build output directory: `frontend/dist` → `dist`).
+
+Updated `docs/development-phases.md` Milestone 8.7 to mark all completed items and add the lint-debt + stale-test entries that surfaced during the PR.
+
+Branch cleanup:
+- Deleted local feature branch `feature/claude-remove-vm-path-hacks-20260408` (merged)
+- Deleted 4 stale local branches that had been merged previously: anomaly-params-form, device-detail-live-values, fix-batch-name-prefix, resume-simulation-monitor-defaults
+- Deleted 3 stale remote branches on origin matching the same names
+
+Remaining consolidation work (tracked in 8.7):
+- Cut a release (README still says 0.3.0)
+- Address #22 (npm audit) and #23 (bundle size)
+- Optional: dead code sweep, Docker quickstart smoke test on a clean env
+
+---
+
 ## 2026-04-08 — Remove VirtualBox shared-folder path hacks from frontend tooling
 
 ### What was done

--- a/docs/development-phases.md
+++ b/docs/development-phases.md
@@ -228,10 +228,14 @@
 - [x] Restore `.github/workflows/ci.yml` (was removed in 6d92a2c pending workflow-scope token)
 - [x] API reference drift fix: document 18 previously undocumented endpoints (anomaly, simulation config, fault, simulation-profile import/export/blank)
 - [x] `RegisterValue` schema: document `oid` field and update stale `value` description
-- [ ] Push feature branch and verify CI pipeline runs green
-- [ ] Backend test health check (`pytest` full run, confirm no skipped/flaky tests)
+- [x] Push feature branch and verify CI pipeline runs green (PR #24, merged 2026-04-09)
+- [x] Backend test health check — full `pytest` runs in CI on every push: 278 tests pass, 65% coverage (verified on PR #24)
+- [x] Clear accumulated lint debt: 91 ruff errors that piled up while CI was off (resolved as part of PR #24)
+- [x] Fix stale test (`test_batch_create_with_prefix`) caught by the now-running CI
+- [x] Issue #21 — Cloudflare Pages build output directory (fixed via Dashboard setting change)
 - [ ] Cut release (resolve README 0.3.0 vs. current unreleased feature gap)
-- [ ] Address issues surfaced during audit: #21 (Cloudflare Pages build config), #22 (npm audit vulnerabilities), #23 (frontend bundle >500KB)
+- [ ] Address remaining audit issues: #22 (npm audit vulnerabilities), #23 (frontend bundle >500KB)
+- [ ] Optional follow-ups: dead code sweep, fresh-environment Docker quickstart smoke test
 
 ---
 


### PR DESCRIPTION
## Summary

Bookkeeping follow-up to PR #24. Updates `docs/development-phases.md` Milestone 8.7 to mark items that were completed in PR #24, and adds a 2026-04-09 marker entry to `docs/development-log.md` recording the merge and the branch cleanup that followed.

No code changes — docs only.

### Specifically marked done in 8.7
- Push feature branch + verify CI green (PR #24 itself)
- Backend pytest health check (CI runs the full suite, 278 tests, 65% coverage)
- Clear accumulated lint debt (91 ruff errors)
- Fix stale `test_batch_create_with_prefix` (caught by the now-running CI)
- #21 Cloudflare Pages build config (closed, fixed via Dashboard)

### Still open in 8.7
- Cut release (README still says 0.3.0)
- #22 npm audit vulnerabilities
- #23 frontend bundle size
- Optional: dead code sweep, Docker quickstart smoke test

## Test plan

- [x] `git diff` review — only doc bookkeeping, no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)