### PR TITLE
fix: isolate test database from production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Simulation engine crash recovery: tasks that crash (e.g. network disconnection) now auto-restart with exponential backoff (max 5 attempts), and DB status correctly updates to "error" when recovery fails
 - Inner adapter errors (e.g. pymodbus write failures) now count toward consecutive error threshold, preventing silent simulation death while device status stays "running"
+- **Test suite now uses an isolated `ghostmeter_test` database** instead of running TRUNCATE on the production database — previously, running pytest inside the backend container would wipe all production data
 - Devices with status=running showed no register values after backend restart (simulation engine was not resumed)
 - Frontend `package.json` scripts no longer hard-code VirtualBox shared-folder workaround paths (`/home/ken/.ghostmeter-frontend-modules/...`); `npm run dev` / `npm run build` / `npm run lint` now use standard tooling and work on any machine after `npm install`
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+import app.database as _db_module
 from app.config import get_settings
 from app.database import Base, get_session
 from app.main import app
@@ -12,32 +13,84 @@ from app.main import app
 settings = get_settings()
 
 
+def _build_test_db_url() -> str:
+    """Derive a test database URL from the production URL.
+
+    Appends '_test' to the database name so tests never touch production data.
+    """
+    base_url = settings.database_url_computed
+    parts = base_url.rsplit("/", 1)
+    return f"{parts[0]}/{parts[1]}_test"
+
+
+def _admin_url() -> str:
+    """URL pointing at the default 'postgres' database for admin DDL."""
+    base_url = settings.database_url_computed
+    parts = base_url.rsplit("/", 1)
+    return f"{parts[0]}/postgres"
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def create_test_database():
+    """Create the test database once per session, drop it at the end."""
+    test_db_name = f"{settings.POSTGRES_DB}_test"
+    admin_engine = create_async_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+
+    async with admin_engine.connect() as conn:
+        await conn.execute(text(f'DROP DATABASE IF EXISTS "{test_db_name}"'))
+        await conn.execute(text(f'CREATE DATABASE "{test_db_name}"'))
+
+    await admin_engine.dispose()
+
+    yield
+
+    admin_engine = create_async_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+    async with admin_engine.connect() as conn:
+        await conn.execute(text(
+            f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            f"WHERE datname = '{test_db_name}' AND pid <> pg_backend_pid()"
+        ))
+        await conn.execute(text(f'DROP DATABASE IF EXISTS "{test_db_name}"'))
+    await admin_engine.dispose()
+
+
 @pytest.fixture(autouse=True)
 async def setup_database():
-    """Create tables before each test and truncate after."""
-    engine = create_async_engine(
-        settings.database_url_computed,
-        echo=False,
+    """Create tables before each test and truncate after.
+
+    Replaces both the FastAPI dependency (get_session) AND the module-level
+    async_session_factory so that code using either path hits the test DB.
+    """
+    test_engine = create_async_engine(_build_test_db_url(), echo=False)
+    test_session_factory = async_sessionmaker(
+        test_engine, class_=AsyncSession, expire_on_commit=False,
     )
 
-    session_factory = async_sessionmaker(
-        engine,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
-
+    # Override FastAPI dependency
     async def override_get_session() -> AsyncGenerator[AsyncSession, None]:
-        async with session_factory() as session:
+        async with test_session_factory() as session:
             yield session
 
     app.dependency_overrides[get_session] = override_get_session
 
-    async with engine.begin() as conn:
+    # Override module-level factory everywhere.
+    # Modules that did `from app.database import async_session_factory`
+    # hold a local binding that must be patched individually.
+    import app.seed.loader as _seed_mod
+    import app.services.monitor_service as _monitor_mod
+    import app.simulation.engine as _engine_mod
+
+    _patched_modules = [_db_module, _seed_mod, _monitor_mod, _engine_mod]
+    _originals = {mod: getattr(mod, "async_session_factory") for mod in _patched_modules}
+    for mod in _patched_modules:
+        mod.async_session_factory = test_session_factory
+
+    async with test_engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
     yield
 
-    async with engine.begin() as conn:
+    async with test_engine.begin() as conn:
         await conn.execute(text(
             "TRUNCATE device_templates, register_definitions, device_instances, "
             "simulation_configs, anomaly_schedules, simulation_profiles, "
@@ -45,7 +98,10 @@ async def setup_database():
             "scenarios, scenario_steps CASCADE"
         ))
 
-    await engine.dispose()
+    # Restore original factories
+    for mod, orig in _originals.items():
+        mod.async_session_factory = orig
+    await test_engine.dispose()
     app.dependency_overrides.pop(get_session, None)
 
 

--- a/backend/tests/test_seed_profiles.py
+++ b/backend/tests/test_seed_profiles.py
@@ -1,36 +1,20 @@
 """Tests for simulation profile seed loading."""
 
-from unittest.mock import patch
-
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from app.config import get_settings
 from app.seed.loader import seed_builtin_profiles, seed_builtin_templates
-
-settings = get_settings()
-
-
-def _fresh_session_factory() -> async_sessionmaker[AsyncSession]:
-    """Create a fresh session factory to avoid stale event loop connections."""
-    engine = create_async_engine(settings.database_url_computed, echo=False)
-    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 
 class TestSeedProfiles:
     async def test_seed_creates_profiles(self, client: AsyncClient) -> None:
         """Seeding creates profiles for built-in templates."""
-        factory = _fresh_session_factory()
-        with patch("app.seed.loader.async_session_factory", factory):
-            await seed_builtin_templates()
-            await seed_builtin_profiles()
+        await seed_builtin_templates()
+        await seed_builtin_profiles()
 
-        # List templates to get IDs
         resp = await client.get("/api/v1/templates")
         templates = resp.json()["data"]
-        assert len(templates) >= 3  # 3 built-in templates
+        assert len(templates) >= 3
 
-        # Each built-in template should have at least one profile
         for t in templates:
             if not t.get("is_builtin"):
                 continue
@@ -39,18 +23,15 @@ class TestSeedProfiles:
             )
             profiles = resp.json()["data"]
             assert len(profiles) >= 1, f"No profile for template {t['name']}"
-            # Default profile should exist
             defaults = [p for p in profiles if p["is_default"]]
             assert len(defaults) == 1, f"Expected 1 default for {t['name']}"
             assert defaults[0]["is_builtin"] is True
 
     async def test_seed_is_idempotent(self, client: AsyncClient) -> None:
         """Running seed twice doesn't create duplicates."""
-        factory = _fresh_session_factory()
-        with patch("app.seed.loader.async_session_factory", factory):
-            await seed_builtin_templates()
-            await seed_builtin_profiles()
-            await seed_builtin_profiles()  # Second run
+        await seed_builtin_templates()
+        await seed_builtin_profiles()
+        await seed_builtin_profiles()
 
         resp = await client.get("/api/v1/templates")
         templates = resp.json()["data"]
@@ -61,7 +42,6 @@ class TestSeedProfiles:
                 f"/api/v1/simulation-profiles?template_id={t['id']}"
             )
             profiles = resp.json()["data"]
-            # Should still be exactly 1, not 2
             names = [p["name"] for p in profiles]
             assert len(names) == len(set(names)), f"Duplicate profiles for {t['name']}"
 
@@ -69,12 +49,9 @@ class TestSeedProfiles:
         self, client: AsyncClient,
     ) -> None:
         """Built-in profile configs are immutable."""
-        factory = _fresh_session_factory()
-        with patch("app.seed.loader.async_session_factory", factory):
-            await seed_builtin_templates()
-            await seed_builtin_profiles()
+        await seed_builtin_templates()
+        await seed_builtin_profiles()
 
-        # Find a builtin profile
         resp = await client.get("/api/v1/templates")
         template = next(t for t in resp.json()["data"] if t.get("is_builtin"))
         resp = await client.get(
@@ -82,7 +59,6 @@ class TestSeedProfiles:
         )
         profile = next(p for p in resp.json()["data"] if p["is_builtin"])
 
-        # Attempt to update configs -> 403
         resp = await client.put(
             f"/api/v1/simulation-profiles/{profile['id']}",
             json={"configs": [{
@@ -93,7 +69,6 @@ class TestSeedProfiles:
         )
         assert resp.status_code == 403
 
-        # But name/description update should work
         resp = await client.put(
             f"/api/v1/simulation-profiles/{profile['id']}",
             json={"name": "Renamed"},
@@ -105,10 +80,8 @@ class TestSeedProfiles:
         self, client: AsyncClient,
     ) -> None:
         """Built-in profiles cannot be deleted."""
-        factory = _fresh_session_factory()
-        with patch("app.seed.loader.async_session_factory", factory):
-            await seed_builtin_templates()
-            await seed_builtin_profiles()
+        await seed_builtin_templates()
+        await seed_builtin_profiles()
 
         resp = await client.get("/api/v1/templates")
         template = next(t for t in resp.json()["data"] if t.get("is_builtin"))

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,32 @@
 # Development Log
 
+## 2026-04-10 — Isolate test database from production
+
+### What was done
+- conftest.py now creates a dedicated `ghostmeter_test` database (session-scoped fixture), runs all tests against it, and drops it on teardown
+- Replaced module-level `async_session_factory` in all modules that import it directly (`app.database`, `app.seed.loader`, `app.services.monitor_service`, `app.simulation.engine`) so that seed loader and other code using `async_session_factory` also hits the test DB
+- Removed `_fresh_session_factory()` workaround from `test_seed_profiles.py` that was creating its own production-pointing session factory
+
+### Why
+Running `pytest` inside the backend container executed `TRUNCATE ... CASCADE` on all production tables via conftest's `setup_database` teardown. This was the root cause of the data loss incident on 2026-04-10 — all device instances, templates, simulation configs, and profiles were wiped when tests ran against the production database.
+
+### Decisions
+- Chose to create/drop a separate database (`ghostmeter_test`) per test session rather than schema isolation, because alembic migrations and the app code assume the `public` schema
+- Patched `async_session_factory` in individual modules rather than switching to a lazy accessor pattern — more explicit and avoids a larger refactor
+
+### Files changed
+- `backend/tests/conftest.py` — test DB creation, module-level factory patching
+- `backend/tests/test_seed_profiles.py` — removed production DB workaround
+- `CHANGELOG.md` — Fixed section
+- `docs/development-log.md` — this entry
+
+### Verification
+- 278/278 tests passed
+- Production DB confirmed intact after full test run (10 devices, 4 templates)
+- ruff lint clean
+
+---
+
 ## 2026-04-10 — Simulation engine crash recovery and error counting fix
 
 ### What was done


### PR DESCRIPTION
## Summary
- 測試現在使用獨立的 `ghostmeter_test` database，不再操作 production DB
- 修復了之前在 container 內跑 pytest 會 TRUNCATE 所有 production data 的致命問題
- 移除 `test_seed_profiles.py` 中指向 production DB 的 workaround

## Root cause
`conftest.py` 的 `setup_database` fixture 在每個 test 結束後對 production DB 執行 `TRUNCATE ... CASCADE`，因為它直接使用 `settings.database_url_computed` 建立 engine，沒有隔離測試環境。

## Test plan
- [x] 278/278 tests passed
- [x] Production DB confirmed intact after full test run (10 devices, 4 templates)
- [x] ruff lint clean
- [x] Test DB (`ghostmeter_test`) auto-created and auto-dropped per session

🤖 Generated with [Claude Code](https://claude.com/claude-code)