### PR TITLE
feat(ui): apply GhostMeter dark visual language globally (issue #28)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+    />
+    <title>GhostMeter</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -8,7 +8,7 @@ import {
   MenuUnfoldOutlined,
   SettingOutlined,
 } from "@ant-design/icons";
-import { Button, Layout, Menu, theme } from "antd";
+import { Button, Layout, Menu } from "antd";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAppStore } from "../stores/appStore";
 
@@ -27,9 +27,6 @@ export function MainLayout() {
   const { sidebarCollapsed, toggleSidebar } = useAppStore();
   const navigate = useNavigate();
   const location = useLocation();
-  const {
-    token: { colorBgContainer, borderRadiusLG },
-  } = theme.useToken();
 
   return (
     <Layout style={{ minHeight: "100vh" }}>
@@ -43,19 +40,17 @@ export function MainLayout() {
             toggleSidebar();
           }
         }}
+        width={220}
+        className="gm-sider"
       >
-        <div
-          style={{
-            height: 32,
-            margin: 16,
-            color: "white",
-            fontWeight: "bold",
-            fontSize: sidebarCollapsed ? 14 : 18,
-            textAlign: "center",
-            lineHeight: "32px",
-          }}
-        >
-          {sidebarCollapsed ? "GM" : "GhostMeter"}
+        <div className={`gm-brand ${sidebarCollapsed ? "gm-brand-collapsed" : ""}`}>
+          <div className="gm-brand-logo">GM</div>
+          {!sidebarCollapsed && (
+            <div className="gm-brand-text">
+              <span className="gm-brand-name">GhostMeter</span>
+              <span className="gm-brand-tag">DEVICE SIMULATOR</span>
+            </div>
+          )}
         </div>
         <Menu
           theme="dark"
@@ -63,17 +58,11 @@ export function MainLayout() {
           selectedKeys={[location.pathname]}
           items={menuItems}
           onClick={({ key }) => navigate(key)}
+          style={{ background: "transparent", border: "none" }}
         />
       </Sider>
       <Layout>
-        <Header
-          style={{
-            padding: "0 16px",
-            background: colorBgContainer,
-            display: "flex",
-            alignItems: "center",
-          }}
-        >
+        <Header className="gm-header">
           <Button
             type="text"
             icon={
@@ -81,16 +70,12 @@ export function MainLayout() {
             }
             onClick={toggleSidebar}
           />
+          <span className="gm-header-live">
+            <span className="gm-header-live-dot" />
+            <span>Live</span>
+          </span>
         </Header>
-        <Content
-          style={{
-            margin: 24,
-            padding: 24,
-            background: colorBgContainer,
-            borderRadius: borderRadiusLG,
-            minHeight: 280,
-          }}
-        >
+        <Content className="gm-content">
           <Outlet />
         </Content>
       </Layout>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,12 +1,19 @@
+import { App as AntdApp, ConfigProvider } from "antd";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
+import { ghostMeterTheme } from "./theme/antdTheme";
+import "./styles/global.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <ConfigProvider theme={ghostMeterTheme}>
+      <AntdApp>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AntdApp>
+    </ConfigProvider>
   </StrictMode>
 );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,210 @@
+/* ===== GhostMeter global styles ===== */
+
+:root {
+  color-scheme: dark;
+
+  --gm-bg-0: #0b0f17;
+  --gm-bg-1: #121826;
+  --gm-bg-2: #1a2030;
+  --gm-border: rgba(148, 163, 184, 0.12);
+  --gm-border-strong: rgba(148, 163, 184, 0.22);
+  --gm-text-1: #e6edf5;
+  --gm-text-2: #9aa5b8;
+  --gm-text-3: #5f6b80;
+  --gm-cyan: #22d3ee;
+  --gm-cyan-soft: rgba(34, 211, 238, 0.14);
+  --gm-emerald: #34d399;
+  --gm-coral: #fb7185;
+  --gm-amber: #fbbf24;
+  --gm-mono: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
+    sans-serif;
+  color: var(--gm-text-1);
+  background:
+    radial-gradient(ellipse 80% 50% at 20% 0%, rgba(34, 211, 238, 0.05), transparent 60%),
+    radial-gradient(ellipse 60% 40% at 100% 20%, rgba(34, 211, 238, 0.03), transparent 60%),
+    var(--gm-bg-0);
+  background-attachment: fixed;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Mono numerals where they matter */
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--gm-mono);
+}
+
+/* Scrollbar refinement */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 10px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(148, 163, 184, 0.22);
+  background-clip: padding-box;
+}
+
+/* Selection */
+::selection {
+  background: rgba(34, 211, 238, 0.3);
+  color: #ffffff;
+}
+
+/* ===== GhostMeter MainLayout refinements ===== */
+
+.gm-sider {
+  border-right: 1px solid var(--gm-border);
+}
+
+.gm-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 20px 16px;
+  border-bottom: 1px solid var(--gm-border);
+  margin-bottom: 8px;
+}
+
+.gm-brand-collapsed {
+  padding: 18px 0 16px;
+  justify-content: center;
+}
+
+.gm-brand-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: linear-gradient(135deg, #22d3ee 0%, #0891b2 100%);
+  display: grid;
+  place-items: center;
+  font-family: var(--gm-mono);
+  font-weight: 700;
+  font-size: 13px;
+  color: #04101a;
+  box-shadow: 0 0 16px rgba(34, 211, 238, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+  flex-shrink: 0;
+}
+
+.gm-brand-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.gm-brand-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--gm-text-1);
+  letter-spacing: -0.01em;
+}
+
+.gm-brand-tag {
+  font-family: var(--gm-mono);
+  font-size: 9.5px;
+  color: var(--gm-cyan);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+.gm-header {
+  border-bottom: 1px solid var(--gm-border);
+  padding: 0 20px !important;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.gm-header-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: rgba(34, 211, 238, 0.08);
+  border: 1px solid rgba(34, 211, 238, 0.22);
+  font-family: var(--gm-mono);
+  font-size: 11px;
+  color: var(--gm-cyan);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.gm-header-live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--gm-cyan);
+  box-shadow: 0 0 8px var(--gm-cyan);
+  animation: gm-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes gm-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(34, 211, 238, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 8px rgba(34, 211, 238, 0);
+  }
+}
+
+.gm-content {
+  margin: 20px !important;
+  padding: 24px !important;
+  background: var(--gm-bg-1) !important;
+  border: 1px solid var(--gm-border);
+  border-radius: 10px;
+}
+
+/* Subtle top-edge cyan line on content card */
+.gm-content {
+  position: relative;
+}
+
+.gm-content::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 12%;
+  right: 12%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--gm-cyan-soft), transparent);
+  pointer-events: none;
+}
+
+/* Make the AntD menu items feel a bit more spacious */
+.gm-sider .ant-menu-item {
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.gm-sider .ant-menu-item-selected {
+  box-shadow: inset 2px 0 0 var(--gm-cyan);
+}

--- a/frontend/src/theme/antdTheme.ts
+++ b/frontend/src/theme/antdTheme.ts
@@ -1,0 +1,100 @@
+import { theme, type ThemeConfig } from "antd";
+
+/** GhostMeter visual language — dark slate base + electric cyan accent. */
+export const ghostMeterTheme: ThemeConfig = {
+  algorithm: theme.darkAlgorithm,
+  token: {
+    // Brand
+    colorPrimary: "#22d3ee",
+    colorInfo: "#22d3ee",
+    colorSuccess: "#34d399",
+    colorWarning: "#fbbf24",
+    colorError: "#fb7185",
+
+    // Surface
+    colorBgBase: "#0b0f17",
+    colorBgLayout: "#0b0f17",
+    colorBgContainer: "#121826",
+    colorBgElevated: "#1a2030",
+
+    // Border / text
+    colorBorder: "rgba(148, 163, 184, 0.12)",
+    colorBorderSecondary: "rgba(148, 163, 184, 0.08)",
+    colorText: "#e6edf5",
+    colorTextSecondary: "#9aa5b8",
+    colorTextTertiary: "#5f6b80",
+    colorTextQuaternary: "#475569",
+
+    // Typography
+    fontFamily:
+      "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",
+    fontFamilyCode:
+      "'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace",
+    fontSize: 14,
+
+    // Shape
+    borderRadius: 8,
+    borderRadiusLG: 10,
+    borderRadiusSM: 6,
+
+    // Motion
+    motionDurationMid: "0.18s",
+  },
+  components: {
+    Layout: {
+      headerBg: "#0b0f17",
+      headerHeight: 56,
+      siderBg: "#0b0f17",
+      bodyBg: "#0b0f17",
+    },
+    Menu: {
+      darkItemBg: "#0b0f17",
+      darkSubMenuItemBg: "#0b0f17",
+      darkItemSelectedBg: "rgba(34, 211, 238, 0.12)",
+      darkItemSelectedColor: "#22d3ee",
+      darkItemHoverBg: "rgba(148, 163, 184, 0.06)",
+      darkItemHoverColor: "#e6edf5",
+      itemBorderRadius: 6,
+      itemMarginInline: 8,
+    },
+    Button: {
+      controlHeight: 34,
+      fontWeight: 500,
+      primaryShadow: "0 0 16px rgba(34, 211, 238, 0.25)",
+    },
+    Card: {
+      colorBgContainer: "#121826",
+      headerBg: "transparent",
+      borderRadiusLG: 10,
+    },
+    Table: {
+      headerBg: "#0f1420",
+      headerColor: "#9aa5b8",
+      headerSplitColor: "rgba(148, 163, 184, 0.12)",
+      borderColor: "rgba(148, 163, 184, 0.08)",
+      rowHoverBg: "rgba(34, 211, 238, 0.04)",
+    },
+    Tag: {
+      borderRadiusSM: 4,
+    },
+    Badge: {
+      dotSize: 8,
+    },
+    Modal: {
+      contentBg: "#121826",
+      headerBg: "#121826",
+    },
+    Input: {
+      colorBgContainer: "#0f1420",
+      activeBorderColor: "#22d3ee",
+      hoverBorderColor: "rgba(34, 211, 238, 0.5)",
+    },
+    Select: {
+      colorBgContainer: "#0f1420",
+    },
+    Tabs: {
+      itemSelectedColor: "#22d3ee",
+      inkBarColor: "#22d3ee",
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Project-wide AntD ConfigProvider theme: dark algorithm, cyan primary, emerald/coral/amber semantic, slate surfaces
- Inter + JetBrains Mono via Google Fonts
- Global CSS: body radial wash, scrollbar refinement, selection color
- MainLayout: branded logo + tag, live indicator in header, cyan-tinted content card

Closes #28. Foundation for #29 (Monitor redesign) and #30 (Devices card view).

## Test plan
- [ ] \`cd frontend && npm run build\` passes
- [ ] \`cd frontend && npm run lint\` passes
- [ ] Manual: open every page (Templates / Devices / Simulation / Scenarios / Monitor / Settings) — dark theme applied, no broken layouts
- [ ] Manual: sidebar shows brand mark + tag, header shows live indicator
- [ ] Lighthouse contrast check on Monitor + Devices pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)