### PR TITLE
docs: mark Milestone 8.9 (OPC UA adapter) as merged

### DIFF
--- a/docs/development-phases.md
+++ b/docs/development-phases.md
@@ -232,13 +232,15 @@
 - [x] Refactor: shared `pickPrimary` helper module; `ProtocolManager.get_adapter` returns Optional with None checks at all call sites
 - [x] Removed DeviceDetailPanel, RegisterChart, StatsPanel, EventLog from Monitor page
 
-### Milestone 8.9：OPC UA Server Adapter ✅
+### Milestone 8.9：OPC UA Server Adapter ✅ Merged (2026-06-03, PR #33)
 - [x] OpcUaAdapter extending ProtocolAdapter (asyncua, single shared server, Anonymous/None)
 - [x] Push value-sync: simulation engine update_register → variable node; subscriptions fire automatically
 - [x] RegisterInfo extended with name/unit; device name via set_device_meta pre-add hook
 - [x] Built-in "Energy Meter (OPC UA)" template (11 registers) + Normal Operation profile
 - [x] Frontend OPC UA protocol option; docker-compose port 4840
 - [x] Integration tests: server lifecycle, node CRUD, typed value round-trip, subscription, device wiring
+- [x] Post-review hardening: out-of-range value clamping, unique `(#slave_id)` node names, `_device_meta` cleanup
+- [x] Merged to `dev` via PR #33; follow-up PR #34 pinned `pymodbus<3.13`
 
 ### Milestone 8.7：Consolidation (in progress 🔄)
 - [x] Remove VirtualBox shared-folder path hacks from `frontend/package.json` + tsconfigs + `.npmrc`


### PR DESCRIPTION
## Summary

Marks Milestone 8.9 (OPC UA Server Adapter) as merged in `docs/development-phases.md`, matching the existing `✅ Complete (date)` convention used by Milestone 8.8.

- Header → `✅ Merged (2026-06-03, PR #33)`
- Added two checklist lines: post-review hardening (value clamping, unique `(#slave_id)` node names, `_device_meta` cleanup) and the merge/follow-up note (PR #33, plus PR #34 pinning `pymodbus<3.13`)

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)