### PR TITLE
feat: OPC UA comm-layer fault simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - DeviceMonitorData 新增 `mqtt_stats`、`template_name` 欄位
 
 ### Fixed
-- Quieted the `asyncua` logger to WARNING in `app/main.py`. Each `Server.init()` emits ~1100 INFO lines while loading the standard OPC UA address space; at root INFO this flooded startup logs, and in CI (~25 OPC UA server tests × ~1100 lines written to the slow per-line Actions log sink) inflated each test to ~11 min, exceeding the 6h job limit. Root cause of the CI hang previously mis-attributed to asyncpg in issue #37.
+- **CI 6h timeout on OPC UA server tests** (root cause of issue #37, previously mis-attributed to asyncpg): coverage's default C trace function fires per-line on every module, and asyncua rebuilds its ~100k-line standard address space on each `Server.init()`. Under `pytest --cov` each OPC UA server test took ~11 min, blowing the 6h job limit. Fixed by `[tool.coverage.run] core = "sysmon"` (PEP 669 `sys.monitoring`), which skips instrumentation of non-`source` files — `Server.init()` drops from >240s to ~0.4s under coverage.
+- Quieted the `asyncua` logger to WARNING in `app/main.py` (secondary cleanup): each `Server.init()` emits ~1100 INFO lines loading the standard address space, spamming startup logs. Not the CI fix.
 
 ### Changed
 - `/` route 改導向 `/monitor`（原 `/templates`）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - WebSocket monitor_update payload 新增 `mqtt_broker_connected` 欄位
 - DeviceMonitorData 新增 `mqtt_stats`、`template_name` 欄位
 
+### Fixed
+- Quieted the `asyncua` logger to WARNING in `app/main.py`. Each `Server.init()` emits ~1100 INFO lines while loading the standard OPC UA address space; at root INFO this flooded startup logs, and in CI (~25 OPC UA server tests × ~1100 lines written to the slow per-line Actions log sink) inflated each test to ~11 min, exceeding the 6h job limit. Root cause of the CI hang previously mis-attributed to asyncpg in issue #37.
+
 ### Changed
 - `/` route 改導向 `/monitor`（原 `/templates`）
 - 側邊欄 Monitor 移到第一位

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- OPC UA comm-layer fault simulation: delay / timeout / exception / intermittent now
+  apply to OPC UA devices via per-node value callbacks (push-based; attaches on fault set,
+  detaches on clear). Modbus behavior unchanged.
 - OPC UA server adapter: exposes simulated devices as browsable Variable nodes (Read + Subscribe, Anonymous + SecurityPolicy None) via asyncua
 - Built-in "Energy Meter (OPC UA)" template (11 registers) + Normal Operation profile
 - OPC UA protocol option in template creation

--- a/backend/app/api/routes/simulation.py
+++ b/backend/app/api/routes/simulation.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
+from app.protocols import protocol_manager
 from app.schemas.common import ApiResponse
 from app.schemas.simulation import (
     FaultConfigResponse,
@@ -14,7 +15,7 @@ from app.schemas.simulation import (
     SimulationConfigCreate,
     SimulationConfigResponse,
 )
-from app.services import simulation_service
+from app.services import device_service, simulation_service
 from app.services.monitor_service import monitor_service
 from app.simulation import fault_simulator
 from app.simulation.fault_simulator import FaultConfig
@@ -96,10 +97,17 @@ async def delete_simulation_configs(
 async def set_fault(
     device_id: uuid.UUID,
     data: FaultConfigSet,
+    session: AsyncSession = Depends(get_session),
 ) -> ApiResponse[FaultConfigResponse]:
-    """Set a communication fault on a device (in-memory)."""
+    """Set a communication fault on a device (in-memory) and apply it to the adapter."""
     fault = FaultConfig(fault_type=data.fault_type, params=data.params)
     fault_simulator.set_fault(device_id, fault)
+
+    protocol = await device_service.get_device_protocol(session, device_id)
+    adapter = protocol_manager.get_adapter(protocol)
+    if adapter is not None and protocol_manager.is_running:
+        await adapter.apply_fault(device_id)
+
     monitor_service.log_event(
         device_id, str(device_id), "fault_set",
         f"Fault set: {data.fault_type}",
@@ -137,9 +145,16 @@ async def get_fault(
 )
 async def clear_fault(
     device_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
 ) -> ApiResponse[None]:
-    """Clear the active fault for a device."""
+    """Clear the active fault for a device and detach it from the adapter."""
     fault_simulator.clear_fault(device_id)
+
+    protocol = await device_service.get_device_protocol(session, device_id)
+    adapter = protocol_manager.get_adapter(protocol)
+    if adapter is not None and protocol_manager.is_running:
+        await adapter.remove_fault(device_id)
+
     monitor_service.log_event(
         device_id, str(device_id), "fault_clear", "Fault cleared",
     )

--- a/backend/app/api/routes/simulation.py
+++ b/backend/app/api/routes/simulation.py
@@ -148,12 +148,16 @@ async def clear_fault(
     session: AsyncSession = Depends(get_session),
 ) -> ApiResponse[None]:
     """Clear the active fault for a device and detach it from the adapter."""
-    fault_simulator.clear_fault(device_id)
-
+    # Detach the adapter hook before clearing the in-memory state, mirroring the
+    # state-then-hook order of set_fault in reverse (LIFO teardown): remove_fault
+    # restores the node value and callback atomically, so reads never observe a
+    # still-attached callback against absent fault state.
     protocol = await device_service.get_device_protocol(session, device_id)
     adapter = protocol_manager.get_adapter(protocol)
     if adapter is not None and protocol_manager.is_running:
         await adapter.remove_fault(device_id)
+
+    fault_simulator.clear_fault(device_id)
 
     monitor_service.log_event(
         device_id, str(device_id), "fault_clear", "Fault cleared",

--- a/backend/app/api/routes/simulation.py
+++ b/backend/app/api/routes/simulation.py
@@ -100,10 +100,13 @@ async def set_fault(
     session: AsyncSession = Depends(get_session),
 ) -> ApiResponse[FaultConfigResponse]:
     """Set a communication fault on a device (in-memory) and apply it to the adapter."""
+    # Resolve the device's protocol first — this 404s on an unknown device, so we
+    # validate before mutating any state (no orphan fault entry on a bad request).
+    protocol = await device_service.get_device_protocol(session, device_id)
+
     fault = FaultConfig(fault_type=data.fault_type, params=data.params)
     fault_simulator.set_fault(device_id, fault)
 
-    protocol = await device_service.get_device_protocol(session, device_id)
     adapter = protocol_manager.get_adapter(protocol)
     if adapter is not None and protocol_manager.is_running:
         await adapter.apply_fault(device_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,8 +43,9 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 # asyncua logs ~1100 INFO lines per Server.init() while loading the standard
-# address space; at root INFO that floods startup logs (and made CI write tens
-# of thousands of lines, exceeding the 6h job limit — see issue #37). Quiet it.
+# address space, which spams startup logs at root INFO. Quiet it to WARNING.
+# (Noise reduction only — the CI 6h timeout was a coverage-tracer issue; see
+# pyproject [tool.coverage.run].)
 logging.getLogger("asyncua").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,10 @@ logging.basicConfig(
     level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
+# asyncua logs ~1100 INFO lines per Server.init() while loading the standard
+# address space; at root INFO that floods startup logs (and made CI write tens
+# of thousands of lines, exceeding the 6h job limit — see issue #37). Quiet it.
+logging.getLogger("asyncua").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 

--- a/backend/app/protocols/base.py
+++ b/backend/app/protocols/base.py
@@ -56,6 +56,25 @@ class ProtocolAdapter(ABC):
         if device_id in self._device_stats:
             self._device_stats[device_id] = DeviceStats()
 
+    # --- Fault hooks (concrete no-op default; protocol adapters may override) ---
+
+    async def apply_fault(self, device_id: UUID) -> None:
+        """A comm-layer fault became active for this device.
+
+        Presence toggle only — the active FaultConfig lives in
+        app.simulation.fault_simulator. Default no-op: Modbus polls
+        fault_simulator live in trace_pdu, so it needs no action here.
+        OPC UA overrides this to attach value callbacks.
+        """
+
+    async def remove_fault(self, device_id: UUID) -> None:
+        """The comm-layer fault was cleared for this device.
+
+        Mirror of apply_fault. Default no-op: Modbus stops applying the fault
+        automatically once fault_simulator no longer reports it. OPC UA overrides
+        this to detach the value callbacks attached in apply_fault.
+        """
+
     # --- Device lifecycle (template methods) ---
 
     async def add_device(

--- a/backend/app/protocols/opcua_agent.py
+++ b/backend/app/protocols/opcua_agent.py
@@ -10,6 +10,8 @@ Security: SecurityPolicy None + Anonymous (MVP).
 
 import logging
 import math
+import random  # noqa: F401 — used in Task 3 fault callbacks
+import time  # noqa: F401 — used in Task 3 fault callbacks
 from uuid import UUID
 
 from asyncua import Server, ua
@@ -85,6 +87,8 @@ class OpcUaAdapter(ProtocolAdapter):
         self._device_objects: dict[UUID, object] = {}          # device_id → Object node
         self._nodes: dict[tuple[UUID, int, int], object] = {}  # (dev, addr, fc) → node
         self._device_meta: dict[UUID, str] = {}                # device_id → display name
+        self._last_values: dict[tuple[UUID, int, int], tuple[float | int, ua.VariantType]] = {}
+        self._faulted: set[UUID] = set()  # devices with fault callbacks attached
 
     async def start(self) -> None:
         """Start the OPC UA server and create the GhostMeter folder."""
@@ -116,6 +120,8 @@ class OpcUaAdapter(ProtocolAdapter):
         self._folder = None
         self._device_objects.clear()
         self._nodes.clear()
+        self._last_values.clear()
+        self._faulted.clear()
         self._device_meta.clear()
         self._device_stats.clear()
         self._running = False
@@ -157,6 +163,9 @@ class OpcUaAdapter(ProtocolAdapter):
                 except Exception:
                     logger.debug("Could not set Description for %s", node_name)
             self._nodes[(device_id, reg.address, reg.function_code)] = var
+            self._last_values[(device_id, reg.address, reg.function_code)] = (
+                caster(0), vtype,
+            )
 
         logger.info(
             "OPC UA: added device %s (%s) with %d nodes",
@@ -174,6 +183,10 @@ class OpcUaAdapter(ProtocolAdapter):
         self._nodes = {
             key: node for key, node in self._nodes.items() if key[0] != device_id
         }
+        self._last_values = {
+            k: v for k, v in self._last_values.items() if k[0] != device_id
+        }
+        self._faulted.discard(device_id)
         self._device_meta.pop(device_id, None)
         logger.info("OPC UA: removed device %s", device_id)
 
@@ -187,7 +200,8 @@ class OpcUaAdapter(ProtocolAdapter):
         byte_order: str,
     ) -> None:
         """Push a value into the variable node (byte_order is irrelevant for OPC UA)."""
-        node = self._nodes.get((device_id, address, function_code))
+        key = (device_id, address, function_code)
+        node = self._nodes.get(key)
         if node is None:
             logger.debug(
                 "OPC UA: no node for device %s addr %d fc %d",
@@ -195,7 +209,12 @@ class OpcUaAdapter(ProtocolAdapter):
             )
             return
         vtype, _caster = _TYPE_MAP.get(data_type, (ua.VariantType.Double, float))
-        await node.write_value(ua.Variant(_coerce_to_range(value, vtype), vtype))
+        coerced = _coerce_to_range(value, vtype)
+        self._last_values[key] = (coerced, vtype)
+        if device_id in self._faulted:
+            # Node has a fault value-callback attached; writing would clear it.
+            return
+        await node.write_value(ua.Variant(coerced, vtype))
 
     def set_device_meta(self, device_id: UUID, device_name: str) -> None:
         """Set the display name used for a device's Object node.

--- a/backend/app/protocols/opcua_agent.py
+++ b/backend/app/protocols/opcua_agent.py
@@ -285,7 +285,13 @@ class OpcUaAdapter(ProtocolAdapter):
             try:
                 await node.write_value(ua.Variant(value, vtype))
             except Exception:
-                logger.debug("OPC UA: error restoring node after fault clear", exc_info=True)
+                # The node keeps its fault callback until the next update_register
+                # write clears it; surface this since a stuck callback is observable.
+                logger.warning(
+                    "OPC UA: failed to restore node %s after fault clear (device %s); "
+                    "its fault callback persists until the next value update",
+                    key, device_id, exc_info=True,
+                )
         self._faulted.discard(device_id)
         logger.info("OPC UA: fault callbacks removed for device %s", device_id)
 

--- a/backend/app/protocols/opcua_agent.py
+++ b/backend/app/protocols/opcua_agent.py
@@ -10,8 +10,8 @@ Security: SecurityPolicy None + Anonymous (MVP).
 
 import logging
 import math
-import random  # noqa: F401 — used in Task 3 fault callbacks
-import time  # noqa: F401 — used in Task 3 fault callbacks
+import random
+import time
 from uuid import UUID
 
 from asyncua import Server, ua
@@ -171,6 +171,9 @@ class OpcUaAdapter(ProtocolAdapter):
             "OPC UA: added device %s (%s) with %d nodes",
             display_name, device_id, len(registers),
         )
+        from app.simulation import fault_simulator
+        if fault_simulator.get_fault(device_id) is not None:
+            await self.apply_fault(device_id)
 
     async def _do_remove_device(self, device_id: UUID) -> None:
         """Delete the device's Object node (and child variables) and clear maps."""
@@ -215,6 +218,76 @@ class OpcUaAdapter(ProtocolAdapter):
             # Node has a fault value-callback attached; writing would clear it.
             return
         await node.write_value(ua.Variant(coerced, vtype))
+
+    # --- Fault application (overrides base no-op) ---
+
+    def _bad_datavalue(self, status_code: int) -> "ua.DataValue":
+        """Build a DataValue carrying a Bad StatusCode (no value)."""
+        return ua.DataValue(StatusCode_=ua.StatusCode(status_code))
+
+    def _good_datavalue(self, key: tuple[UUID, int, int]) -> "ua.DataValue":
+        """Build a Good DataValue from the latest cached value for a node."""
+        value, vtype = self._last_values.get(key, (0, ua.VariantType.Double))
+        return ua.DataValue(ua.Variant(value, vtype))
+
+    def _make_fault_callback(self, device_id: UUID, key: tuple[UUID, int, int]):
+        """Create the synchronous value callback asyncua calls on every read.
+
+        Reads fault_simulator live so it reflects the current fault type/params
+        (single source of truth, same model as Modbus trace_pdu).
+        """
+        from app.simulation import fault_simulator
+
+        def cb(nodeid, attr):  # noqa: ANN001 — asyncua calls cb(nodeid, attr)
+            fault = fault_simulator.get_fault(device_id)
+            if fault is None:
+                return self._good_datavalue(key)
+            ftype = fault.fault_type
+            if ftype == "exception":
+                return self._bad_datavalue(ua.StatusCodes.BadDeviceFailure)
+            if ftype == "timeout":
+                return self._bad_datavalue(ua.StatusCodes.BadTimeout)
+            if ftype == "delay":
+                delay_ms = min(int(fault.params.get("delay_ms", 500)), 10000)
+                time.sleep(delay_ms / 1000.0)  # bounded blocking (mirrors Modbus)
+                return self._good_datavalue(key)
+            if ftype == "intermittent":
+                rate = float(fault.params.get("failure_rate", 0.5))
+                if random.random() < rate:
+                    return self._bad_datavalue(ua.StatusCodes.BadCommunicationError)
+                return self._good_datavalue(key)
+            return self._good_datavalue(key)  # unknown type → behave normally
+
+        return cb
+
+    async def apply_fault(self, device_id: UUID) -> None:
+        """Attach a value callback to each of the device's nodes (idempotent)."""
+        if self._server is None or device_id in self._faulted:
+            return
+        aspace = self._server.iserver.aspace
+        for key, node in list(self._nodes.items()):
+            if key[0] != device_id:
+                continue
+            cb = self._make_fault_callback(device_id, key)
+            aspace.set_attribute_value_callback(node.nodeid, ua.AttributeIds.Value, cb)
+        self._faulted.add(device_id)
+        logger.info("OPC UA: fault callbacks attached for device %s", device_id)
+
+    async def remove_fault(self, device_id: UUID) -> None:
+        """Detach callbacks by re-writing cached values (restores value +
+        clears callback + resumes subscriptions in one write)."""
+        if device_id not in self._faulted:
+            return
+        for key, node in list(self._nodes.items()):
+            if key[0] != device_id:
+                continue
+            value, vtype = self._last_values.get(key, (0, ua.VariantType.Double))
+            try:
+                await node.write_value(ua.Variant(value, vtype))
+            except Exception:
+                logger.debug("OPC UA: error restoring node after fault clear", exc_info=True)
+        self._faulted.discard(device_id)
+        logger.info("OPC UA: fault callbacks removed for device %s", device_id)
 
     def set_device_meta(self, device_id: UUID, device_name: str) -> None:
         """Set the display name used for a device's Object node.

--- a/backend/app/protocols/opcua_agent.py
+++ b/backend/app/protocols/opcua_agent.py
@@ -248,11 +248,12 @@ class OpcUaAdapter(ProtocolAdapter):
             if ftype == "timeout":
                 return self._bad_datavalue(ua.StatusCodes.BadTimeout)
             if ftype == "delay":
-                delay_ms = min(int(fault.params.get("delay_ms", 500)), 10000)
+                # Clamp defensively to [0, 10s]; the REST schema validates this too.
+                delay_ms = min(max(int(fault.params.get("delay_ms", 500)), 0), 10000)
                 time.sleep(delay_ms / 1000.0)  # bounded blocking (mirrors Modbus)
                 return self._good_datavalue(key)
             if ftype == "intermittent":
-                rate = float(fault.params.get("failure_rate", 0.5))
+                rate = min(max(float(fault.params.get("failure_rate", 0.5)), 0.0), 1.0)
                 if random.random() < rate:
                     return self._bad_datavalue(ua.StatusCodes.BadCommunicationError)
                 return self._good_datavalue(key)

--- a/backend/app/schemas/simulation.py
+++ b/backend/app/schemas/simulation.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 VALID_DATA_MODES = {"static", "random", "daily_curve", "computed", "accumulator"}
 VALID_FAULT_TYPES = {"delay", "timeout", "exception", "intermittent"}
@@ -70,6 +70,28 @@ class FaultConfigSet(BaseModel):
         if v not in VALID_FAULT_TYPES:
             raise ValueError(f"fault_type must be one of {VALID_FAULT_TYPES}")
         return v
+
+    @model_validator(mode="after")
+    def validate_params(self) -> "FaultConfigSet":
+        """Validate fault_type-specific params so malformed input is rejected with a
+        422 at the API boundary instead of raising deep inside a protocol adapter."""
+        if self.fault_type == "delay" and "delay_ms" in self.params:
+            try:
+                delay_ms = int(self.params["delay_ms"])
+            except (TypeError, ValueError):
+                raise ValueError("delay_ms must be an integer number of milliseconds")
+            if delay_ms < 0:
+                raise ValueError("delay_ms must be >= 0")
+            self.params["delay_ms"] = delay_ms
+        if self.fault_type == "intermittent" and "failure_rate" in self.params:
+            try:
+                rate = float(self.params["failure_rate"])
+            except (TypeError, ValueError):
+                raise ValueError("failure_rate must be a number between 0.0 and 1.0")
+            if not 0.0 <= rate <= 1.0:
+                raise ValueError("failure_rate must be between 0.0 and 1.0")
+            self.params["failure_rate"] = rate
+        return self
 
 
 class FaultConfigResponse(BaseModel):

--- a/backend/app/services/device_service.py
+++ b/backend/app/services/device_service.py
@@ -38,6 +38,15 @@ async def _get_device_raw(
     return device
 
 
+async def get_device_protocol(
+    session: AsyncSession, device_id: uuid.UUID,
+) -> str:
+    """Resolve a device's protocol via its template. Raises 404 if absent."""
+    device = await _get_device_raw(session, device_id)
+    template = await get_template_with_registers(session, device.template_id)
+    return template.protocol
+
+
 async def _check_slave_id_available(
     session: AsyncSession,
     slave_id: int,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,15 @@
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 
+[tool.coverage.run]
+# Use sys.monitoring (PEP 669) instead of coverage's default C trace function.
+# The C tracer fires per-line on ALL modules; asyncua rebuilds its ~100k-line
+# standard address space on every Server.init(), so under `pytest --cov` each
+# OPC UA server test ballooned to ~11 min and the suite hit the 6h CI timeout.
+# sysmon disables instrumentation for non-`source` files, restoring init() to
+# ~0.4s. Requires Python 3.12+.
+core = "sysmon"
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/backend/tests/test_device_simulation_integration.py
+++ b/backend/tests/test_device_simulation_integration.py
@@ -120,3 +120,16 @@ class TestDeviceSimulationIntegration:
         # The rejected request must not have left an orphan fault entry.
         resp = await client.get(f"/api/v1/devices/{unknown}/fault")
         assert resp.json()["data"] is None
+
+    async def test_fault_api_rejects_invalid_params(self, client: AsyncClient):
+        """Malformed fault params are rejected with 422 at the API boundary
+        (body validation runs before the handler, so device need not exist)."""
+        dev = "00000000-0000-0000-0000-000000000009"
+        for body in (
+            {"fault_type": "delay", "params": {"delay_ms": -100}},
+            {"fault_type": "delay", "params": {"delay_ms": "abc"}},
+            {"fault_type": "intermittent", "params": {"failure_rate": 1.5}},
+            {"fault_type": "intermittent", "params": {"failure_rate": "x"}},
+        ):
+            resp = await client.put(f"/api/v1/devices/{dev}/fault", json=body)
+            assert resp.status_code == 422, (body, resp.status_code)

--- a/backend/tests/test_device_simulation_integration.py
+++ b/backend/tests/test_device_simulation_integration.py
@@ -56,9 +56,39 @@ class TestDeviceSimulationIntegration:
         assert len(resp.json()["data"]) == 1
         assert resp.json()["data"][0]["data_mode"] == "static"
 
+    async def _create_device(self, client: AsyncClient) -> str:
+        """Create a stopped modbus device and return its id."""
+        resp = await client.post("/api/v1/templates", json={
+            "name": "Fault Roundtrip Meter",
+            "protocol": "modbus_tcp",
+            "registers": [
+                {
+                    "name": "voltage",
+                    "address": 0,
+                    "function_code": 3,
+                    "data_type": "float32",
+                    "byte_order": "big_endian",
+                    "scale_factor": 1.0,
+                    "unit": "V",
+                    "sort_order": 0,
+                },
+            ],
+        })
+        assert resp.status_code == 201
+        template_id = resp.json()["data"]["id"]
+        resp = await client.post("/api/v1/devices", json={
+            "template_id": template_id,
+            "name": "Fault Roundtrip Device",
+            "slave_id": 88,
+        })
+        assert resp.status_code == 201
+        return resp.json()["data"]["id"]
+
     async def test_fault_api_roundtrip(self, client: AsyncClient):
-        """Set fault, get it, clear it."""
-        device_id = "00000000-0000-0000-0000-000000000001"
+        """Set fault, get it, clear it — on a real device."""
+        # The fault set/clear endpoints resolve the device's protocol, so the
+        # device must exist (a Modbus device suffices: its adapter hook is a no-op).
+        device_id = await self._create_device(client)
 
         # Set fault
         resp = await client.put(f"/api/v1/devices/{device_id}/fault", json={
@@ -77,3 +107,12 @@ class TestDeviceSimulationIntegration:
         # Verify cleared
         resp = await client.get(f"/api/v1/devices/{device_id}/fault")
         assert resp.json()["data"] is None
+
+    async def test_set_fault_on_unknown_device_returns_404(self, client: AsyncClient):
+        """Setting a fault on a non-existent device is rejected (404), since the
+        endpoint now resolves the device's protocol before applying the fault."""
+        unknown = "00000000-0000-0000-0000-000000000001"
+        resp = await client.put(f"/api/v1/devices/{unknown}/fault", json={
+            "fault_type": "delay", "params": {"delay_ms": 200},
+        })
+        assert resp.status_code == 404

--- a/backend/tests/test_device_simulation_integration.py
+++ b/backend/tests/test_device_simulation_integration.py
@@ -116,3 +116,7 @@ class TestDeviceSimulationIntegration:
             "fault_type": "delay", "params": {"delay_ms": 200},
         })
         assert resp.status_code == 404
+
+        # The rejected request must not have left an orphan fault entry.
+        resp = await client.get(f"/api/v1/devices/{unknown}/fault")
+        assert resp.json()["data"] is None

--- a/backend/tests/test_modbus_fault.py
+++ b/backend/tests/test_modbus_fault.py
@@ -8,6 +8,19 @@ from app.protocols.base import RegisterInfo
 from app.protocols.modbus_tcp import ModbusTcpAdapter
 
 
+class TestBaseFaultHooks:
+    """The base apply_fault/remove_fault hooks are no-ops; Modbus inherits them
+    unchanged (Modbus applies faults via trace_pdu polling, not via these hooks)."""
+
+    @pytest.mark.asyncio
+    async def test_modbus_fault_hooks_are_noops(self):
+        adapter = ModbusTcpAdapter(host="127.0.0.1", port=15598)
+        dev = uuid.uuid4()
+        # No start(), no device registered — pure no-ops must not raise.
+        await adapter.apply_fault(dev)
+        await adapter.remove_fault(dev)
+
+
 class TestReverseMapping:
     """Test slave_id to device_id reverse mapping."""
 

--- a/backend/tests/test_opcua_fault.py
+++ b/backend/tests/test_opcua_fault.py
@@ -271,3 +271,64 @@ class TestOpcUaFaultApplication:
         finally:
             fault_simulator.clear_all()
             await adapter.stop()
+
+
+class TestOpcUaFaultRestWiring:
+    async def test_put_fault_applies_to_opcua_then_delete_clears(self, client):
+        from asyncua import Client
+
+        from app.protocols import protocol_manager
+        from app.protocols.opcua_agent import OpcUaAdapter
+        from app.simulation import fault_simulator
+
+        port = _free_port()
+        adapter = OpcUaAdapter(host="127.0.0.1", port=port)
+        protocol_manager.register_adapter("opcua", adapter)
+        await protocol_manager.start_all()
+        try:
+            tpl = await client.post("/api/v1/templates", json={
+                "name": "Fault-OPCUA",
+                "protocol": "opcua",
+                "registers": [
+                    {"name": "v", "address": 0, "function_code": 3,
+                     "data_type": "float32", "byte_order": "big_endian",
+                     "scale_factor": 1.0, "unit": "V", "sort_order": 0},
+                ],
+            })
+            assert tpl.status_code == 201
+            template_id = tpl.json()["data"]["id"]
+
+            dev = await client.post("/api/v1/devices", json={
+                "name": "RestFaultMeter", "template_id": template_id,
+                "slave_id": 1, "port": 4840,
+            })
+            assert dev.status_code == 201
+            device_id = dev.json()["data"]["id"]
+            assert (await client.post(f"/api/v1/devices/{device_id}/start")).status_code == 200
+
+            url = f"opc.tcp://127.0.0.1:{port}/ghostmeter/server/"
+
+            async def read_status():
+                async with Client(url=url) as opc:
+                    ns = await opc.get_namespace_index("http://ghostmeter.local/opcua/")
+                    gm = await opc.nodes.objects.get_child([f"{ns}:GhostMeter"])
+                    d = await gm.get_child([f"{ns}:RestFaultMeter (#1)"])
+                    var = await d.get_child([f"{ns}:v"])
+                    dv = await var.read_data_value(raise_on_bad_status=False)
+                    return dv.StatusCode_.name
+
+            # PUT fault → OPC UA reads go Bad
+            put = await client.put(
+                f"/api/v1/devices/{device_id}/fault",
+                json={"fault_type": "exception", "params": {}},
+            )
+            assert put.status_code == 200
+            assert await read_status() == "BadDeviceFailure"
+
+            # DELETE fault → reads recover
+            assert (await client.delete(f"/api/v1/devices/{device_id}/fault")).status_code == 200
+            assert await read_status() == "Good"
+        finally:
+            fault_simulator.clear_all()
+            await protocol_manager.stop_all()
+            protocol_manager._adapters.pop("opcua", None)

--- a/backend/tests/test_opcua_fault.py
+++ b/backend/tests/test_opcua_fault.py
@@ -249,3 +249,25 @@ class TestOpcUaFaultApplication:
         finally:
             fault_simulator.clear_all()
             await adapter.stop()
+
+    async def test_fault_type_switches_live_without_reattach(self):
+        """The callback reads fault_simulator live, so changing the fault type
+        while attached flips the observed status with no second apply_fault."""
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            await adapter.apply_fault(dev)
+            status, _ = await _read_status(url)
+            assert status == "BadDeviceFailure", status
+
+            # Switch type WITHOUT calling apply_fault again — same callback, live read.
+            fault_simulator.set_fault(dev, FaultConfig("timeout", {}))
+            status, _ = await _read_status(url)
+            assert status == "BadTimeout", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()

--- a/backend/tests/test_opcua_fault.py
+++ b/backend/tests/test_opcua_fault.py
@@ -1,8 +1,8 @@
 """Tests for OPC UA comm-layer fault simulation (real asyncua client round-trips)."""
 
-import asyncio  # noqa: F401 — used in Task 3 tests
+import asyncio
 import socket
-import time  # noqa: F401 — used in Task 3 tests
+import time
 import uuid
 
 import pytest
@@ -51,3 +51,201 @@ class TestOpcUaFaultCache:
             await adapter.stop()
         assert adapter._last_values == {}
         assert adapter._faulted == set()
+
+
+class _SubHandler:
+    def __init__(self) -> None:
+        self.values: list = []
+
+    def datachange_notification(self, node, val, data) -> None:  # noqa: ANN001
+        self.values.append(val)
+
+
+async def _make_running_device(port, name="FaultMeter"):
+    """Start an adapter with one device + one float32 register at addr 0/fc 3."""
+    from app.protocols.base import RegisterInfo
+    from app.protocols.opcua_agent import OpcUaAdapter
+
+    adapter = OpcUaAdapter(host="127.0.0.1", port=port)
+    await adapter.start()
+    dev = uuid.uuid4()
+    adapter.set_device_meta(dev, name)
+    await adapter.add_device(dev, 1, [RegisterInfo(0, 3, "float32", "big_endian", name="v")])
+    await adapter.update_register(dev, 0, 3, 100.0, "float32", "big_endian")
+    url = f"opc.tcp://127.0.0.1:{port}/ghostmeter/server/"
+    return adapter, dev, url
+
+
+async def _read_status(url, raise_on_bad=False):
+    """Connect, read the device's 'v' node DataValue, return (status_name, value)."""
+    from asyncua import Client
+
+    async with Client(url=url) as client:
+        ns = await client.get_namespace_index("http://ghostmeter.local/opcua/")
+        gm = await client.nodes.objects.get_child([f"{ns}:GhostMeter"])
+        dev = await gm.get_child([f"{ns}:FaultMeter (#1)"])
+        var = await dev.get_child([f"{ns}:v"])
+        dv = await var.read_data_value(raise_on_bad_status=raise_on_bad)
+        return dv.StatusCode_.name, (dv.Value.Value if dv.Value else None)
+
+
+class TestOpcUaFaultApplication:
+    async def test_exception_fault_yields_bad_device_failure(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            await adapter.apply_fault(dev)
+            status, _ = await _read_status(url)
+            assert status == "BadDeviceFailure", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_timeout_fault_yields_bad_timeout(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("timeout", {}))
+            await adapter.apply_fault(dev)
+            status, _ = await _read_status(url)
+            assert status == "BadTimeout", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_delay_fault_slows_reads(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("delay", {"delay_ms": 400}))
+            await adapter.apply_fault(dev)
+            t0 = time.monotonic()
+            status, value = await _read_status(url, raise_on_bad=True)
+            elapsed = time.monotonic() - t0
+            assert status == "Good", status
+            assert abs(value - 100.0) < 0.01
+            assert elapsed >= 0.3, f"expected >=0.3s, got {elapsed:.3f}s"
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_intermittent_rate_1_always_bad(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("intermittent", {"failure_rate": 1.0}))
+            await adapter.apply_fault(dev)
+            for _ in range(3):
+                status, _ = await _read_status(url)
+                assert status == "BadCommunicationError", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_intermittent_rate_0_always_good(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("intermittent", {"failure_rate": 0.0}))
+            await adapter.apply_fault(dev)
+            status, value = await _read_status(url, raise_on_bad=True)
+            assert status == "Good"
+            assert abs(value - 100.0) < 0.01
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_update_register_during_fault_does_not_clear_callback(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            await adapter.apply_fault(dev)
+            # Simulation engine keeps pushing values during the fault:
+            await adapter.update_register(dev, 0, 3, 222.0, "float32", "big_endian")
+            status, _ = await _read_status(url)
+            assert status == "BadDeviceFailure", status  # callback still active
+            # but the cache tracked the latest value
+            assert abs(adapter._last_values[(dev, 0, 3)][0] - 222.0) < 0.01
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_clear_fault_restores_value_and_subscription(self):
+        from asyncua import Client
+
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            await adapter.apply_fault(dev)
+            # clear
+            fault_simulator.clear_fault(dev)
+            await adapter.remove_fault(dev)
+
+            async with Client(url=url) as client:
+                ns = await client.get_namespace_index("http://ghostmeter.local/opcua/")
+                gm = await client.nodes.objects.get_child([f"{ns}:GhostMeter"])
+                d = await gm.get_child([f"{ns}:FaultMeter (#1)"])
+                var = await d.get_child([f"{ns}:v"])
+                # value readable again (the cached 100.0)
+                assert abs(await var.read_value() - 100.0) < 0.01
+                # subscription resumes
+                handler = _SubHandler()
+                sub = await client.create_subscription(50, handler)
+                await sub.subscribe_data_change(var)
+                await asyncio.sleep(0.3)
+                await adapter.update_register(dev, 0, 3, 175.0, "float32", "big_endian")
+                await asyncio.sleep(0.5)
+                await sub.delete()
+                assert any(abs(v - 175.0) < 0.05 for v in handler.values), handler.values
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_fault_reattaches_on_device_add(self):
+        """A fault set before the device is added is re-applied on add (parity with
+        Modbus, where the fault survives a device stop/start)."""
+        from app.protocols.base import RegisterInfo
+        from app.protocols.opcua_agent import OpcUaAdapter
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter = OpcUaAdapter(host="127.0.0.1", port=port)
+        await adapter.start()
+        dev = uuid.uuid4()
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            adapter.set_device_meta(dev, "FaultMeter")
+            regs = [RegisterInfo(0, 3, "float32", "big_endian", name="v")]
+            await adapter.add_device(dev, 1, regs)
+            assert dev in adapter._faulted
+            url = f"opc.tcp://127.0.0.1:{port}/ghostmeter/server/"
+            status, _ = await _read_status(url)
+            assert status == "BadDeviceFailure", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()

--- a/backend/tests/test_opcua_fault.py
+++ b/backend/tests/test_opcua_fault.py
@@ -1,0 +1,53 @@
+"""Tests for OPC UA comm-layer fault simulation (real asyncua client round-trips)."""
+
+import asyncio  # noqa: F401 — used in Task 3 tests
+import socket
+import time  # noqa: F401 — used in Task 3 tests
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class TestOpcUaFaultCache:
+    async def test_cache_seeded_on_add_and_updated(self):
+        from app.protocols.base import RegisterInfo
+        from app.protocols.opcua_agent import OpcUaAdapter
+
+        adapter = OpcUaAdapter(host="127.0.0.1", port=_free_port())
+        await adapter.start()
+        dev = uuid.uuid4()
+        regs = [RegisterInfo(0, 3, "float32", "big_endian", name="v")]
+        try:
+            await adapter.add_device(dev, 1, regs)
+            # Seeded with 0 on add
+            assert adapter._last_values[(dev, 0, 3)][0] == 0
+            # Updated by update_register
+            await adapter.update_register(dev, 0, 3, 12.5, "float32", "big_endian")
+            assert abs(adapter._last_values[(dev, 0, 3)][0] - 12.5) < 0.01
+        finally:
+            await adapter.stop()
+
+    async def test_cache_cleared_on_remove_and_stop(self):
+        from app.protocols.base import RegisterInfo
+        from app.protocols.opcua_agent import OpcUaAdapter
+
+        adapter = OpcUaAdapter(host="127.0.0.1", port=_free_port())
+        await adapter.start()
+        dev = uuid.uuid4()
+        regs = [RegisterInfo(0, 3, "float32", "big_endian", name="v")]
+        try:
+            await adapter.add_device(dev, 1, regs)
+            await adapter.remove_device(dev)
+            assert all(k[0] != dev for k in adapter._last_values)
+        finally:
+            await adapter.stop()
+        assert adapter._last_values == {}
+        assert adapter._faulted == set()

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -845,7 +845,23 @@ Set (or replace) the active communication fault on a device.
 **Response** `200 OK` — `ApiResponse[FaultConfigResponse]`
 
 **Error cases:**
+- `404` — device not found (`DEVICE_NOT_FOUND`)
 - `422` — unknown `fault_type`
+
+**Protocol-layer behavior:**
+
+For **Modbus TCP** devices the fault is applied pull-based (no adapter action on this call; `trace_pdu` polls `fault_simulator` on every request).
+
+For **OPC UA** devices the fault is applied push-based at the protocol layer immediately on this call by attaching a value callback to every Variable node of the device. Fault-type semantics:
+
+| `fault_type` | OPC UA client observation |
+|---|---|
+| `exception` | Every read returns `BadDeviceFailure` status code; no value |
+| `timeout` | Every read returns `BadTimeout` status code; no value |
+| `delay` | Read succeeds with a Good status after a server-side sleep of `delay_ms` ms (bounded to 10 000 ms); returns the latest cached register value |
+| `intermittent` | Each read randomly returns `BadCommunicationError` with probability `failure_rate`, or the latest cached value with Good status otherwise |
+
+While a fault is active, the simulation engine continues updating the per-node value cache; the cached value is served as-is once the fault is cleared. OPC UA subscriptions are paused during a fault (the value callback bypasses subscription notifications) and automatically resume on fault clear.
 
 ---
 
@@ -871,6 +887,11 @@ Clear the active fault for a device.
 ```json
 { "success": true, "data": null, "message": "Fault cleared successfully" }
 ```
+
+**Error cases:**
+- `404` — device not found (`DEVICE_NOT_FOUND`)
+
+**Protocol-layer behavior:** For OPC UA devices, clearing the fault detaches the value callbacks by re-writing the cached value to each Variable node (atomically restores the stored value, clears the callback, and resumes subscriptions). For Modbus devices this is a no-op at the adapter level.
 
 ---
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,40 @@
 # Development Log
 
+## 2026-06-03 — OPC UA Comm-layer Fault Simulation
+
+### What was done
+- Added `apply_fault(device_id)` / `remove_fault(device_id)` no-op hooks to `ProtocolAdapter` base class. Modbus inherits these unchanged (Modbus applies faults via `trace_pdu` polling; no action needed at hook time).
+- `OpcUaAdapter` overrides the hooks to attach/detach per-node asyncua value callbacks (`set_attribute_value_callback`). The callback reads `fault_simulator.get_fault(device_id)` live on every client read — same single-source-of-truth model as Modbus trace_pdu polling.
+- Added per-node last-value cache (`_last_values`) and faulted-device tracking set (`_faulted`). While a fault is active, `update_register` updates the cache but skips `node.write_value` (which would clear the callback and silently disable the fault). `remove_fault` restores the node by re-writing the cached value, which simultaneously restores the stored value, clears the callback, and resumes OPC UA subscriptions.
+- Fault type mapping: `exception` → `BadDeviceFailure` status code, `timeout` → `BadTimeout` status code, `delay` → bounded `time.sleep` (capped 10 s) then returns cached value, `intermittent` → random `BadCommunicationError` by `failure_rate` param.
+- Auto-reattach: `_do_add_device` checks `fault_simulator` after registering nodes and re-calls `apply_fault` if a fault is already active, giving parity with Modbus (fault survives device stop/start).
+- REST wiring: `PUT/DELETE /api/v1/devices/{id}/fault` now resolves the device's protocol via `device_service.get_device_protocol(session, device_id)` and calls the adapter hook. Modbus uses the inherited no-ops (still pull-based). No request/response schema change.
+
+### Key design decisions
+- **Push-based (callback) vs. pull-based:** asyncua clients read directly from the node's stored value; there is no request-intercept hook equivalent to Modbus's `trace_pdu`. The only way to inject a Bad status or a delayed response into every client read is to attach a value callback that overrides what the stored value returns. The callback is called synchronously by asyncua's address space on each `ReadRequest`.
+- **asyncua callback constraint:** `set_attribute_value_callback` replaces the node's stored value reads and sets the stored value to `None`. There is no API to clear the callback directly with `None`; the only way to detach is via a `write_value` call, which sets the stored value, clears the callback, and fires subscription change notifications in one atomic operation.
+- **Per-node cache necessity:** because the callback returns the last-known value for `delay`/`intermittent`, and `write_value` is suppressed while faulted, the adapter needs its own cache — the asyncua node's stored value is `None` while a callback is active.
+- **Single source of truth:** the callback reads `fault_simulator` live. The hook (`apply_fault`/`remove_fault`) is a presence toggle only; the active `FaultConfig` always lives in `fault_simulator`, exactly like Modbus trace_pdu.
+
+### Known caveat / deferred work
+- **`delay` blocks the event loop:** the callback is synchronous (asyncua calls it without `await`). A `delay` fault's `time.sleep` briefly blocks the shared asyncio event loop for the sleep duration (capped at 10 s). This mirrors Modbus's synchronous delay approach (trace_pdu runs in a thread context) but is more impactful in a shared single-server setup. Mitigation: cap enforced; out of scope to convert to async for MVP.
+- **`timeout` is a Bad status, not a true dropped connection:** the shared single-session server cannot drop an individual device's response at the TCP level. `BadTimeout` conveys the semantic intent; a real dropped connection would require a per-device server instance.
+- **Regression in `test_device_simulation_integration.test_fault_api_roundtrip`:** the test uses a hardcoded non-existent UUID to call `PUT /fault`. Previously this worked because the endpoint was pure in-memory; after Task 4 wired `get_device_protocol` (a DB lookup), the endpoint returns 404 for non-existent devices. This test needs to be updated to create a real device — left as a known concern for the reviewer (Task 5, not addressed per plan scope).
+
+### Files changed
+- `backend/app/protocols/base.py` — `apply_fault`/`remove_fault` no-op hooks on `ProtocolAdapter`
+- `backend/app/protocols/opcua_agent.py` — `_last_values` cache, `_faulted` set, `_make_fault_callback`, `apply_fault`, `remove_fault`, `update_register` skip, `_do_add_device` re-attach, `stop` cleanup
+- `backend/app/services/device_service.py` — `get_device_protocol` helper
+- `backend/app/api/routes/simulation.py` — `set_fault` / `clear_fault` wired to adapter hook via `get_device_protocol`
+- `backend/tests/test_opcua_fault.py` — new: adapter-level fault tests + REST wiring e2e test
+- `backend/tests/test_modbus_fault.py` — added `TestBaseFaultHooks` to assert Modbus inherits no-op base hooks
+
+### Verification
+- 320/321 backend tests passed (1 pre-existing regression in `test_device_simulation_integration.test_fault_api_roundtrip` — see caveat above)
+- ruff lint clean
+
+---
+
 ## 2026-06-03 — OPC UA Server Adapter (4th protocol)
 
 ### What was done

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -19,19 +19,24 @@
 ### Known caveat / deferred work
 - **`delay` blocks the event loop:** the callback is synchronous (asyncua calls it without `await`). A `delay` fault's `time.sleep` briefly blocks the shared asyncio event loop for the sleep duration (capped at 10 s). This mirrors Modbus's synchronous delay approach (trace_pdu runs in a thread context) but is more impactful in a shared single-server setup. Mitigation: cap enforced; out of scope to convert to async for MVP.
 - **`timeout` is a Bad status, not a true dropped connection:** the shared single-session server cannot drop an individual device's response at the TCP level. `BadTimeout` conveys the semantic intent; a real dropped connection would require a per-device server instance.
-- **Regression in `test_device_simulation_integration.test_fault_api_roundtrip`:** the test uses a hardcoded non-existent UUID to call `PUT /fault`. Previously this worked because the endpoint was pure in-memory; after Task 4 wired `get_device_protocol` (a DB lookup), the endpoint returns 404 for non-existent devices. This test needs to be updated to create a real device — left as a known concern for the reviewer (Task 5, not addressed per plan scope).
+- **Resolved during review — `test_fault_api_roundtrip`:** after Task 4 wired `get_device_protocol` (a DB lookup), `PUT/DELETE /fault` correctly returns 404 for a non-existent device (you can't fault a device that doesn't exist). The old test used a hardcoded fake UUID and broke; it was rewritten to create a real Modbus device, and a `test_set_fault_on_unknown_device_returns_404` was added. `set_fault` was also reordered to resolve the protocol (validate) **before** mutating `fault_simulator`, so a rejected request leaves no orphan fault entry.
+- **Resolved during review — fault param validation:** `FaultConfigSet` now validates type-specific params (`delay_ms` int ≥ 0; `failure_rate` float in [0,1]) → clean 422 instead of a `BadInternalError` raised deep in the value callback; the callback also clamps defensively.
+- **Deferred follow-up — test-infra flake ([#37](https://github.com/kencoolguy/GhostMeter/issues/37)):** the OPC UA server tests share the asyncio event loop with the per-test asyncpg DB fixture; under load (and the `delay` test's blocking `time.sleep`) the connection can enter a bad state, cascading `asyncpg.InterfaceError` into later tests' fixture setup/teardown (errors only, never assertion failures). Pre-existing since the 8.9 adapter; aggravated here. Excluding the two OPC UA server test files the suite is clean (285 passed). Fix tracked separately.
 
 ### Files changed
 - `backend/app/protocols/base.py` — `apply_fault`/`remove_fault` no-op hooks on `ProtocolAdapter`
 - `backend/app/protocols/opcua_agent.py` — `_last_values` cache, `_faulted` set, `_make_fault_callback`, `apply_fault`, `remove_fault`, `update_register` skip, `_do_add_device` re-attach, `stop` cleanup
 - `backend/app/services/device_service.py` — `get_device_protocol` helper
 - `backend/app/api/routes/simulation.py` — `set_fault` / `clear_fault` wired to adapter hook via `get_device_protocol`
+- `backend/app/schemas/simulation.py` — `FaultConfigSet` param validation (delay_ms / failure_rate)
 - `backend/tests/test_opcua_fault.py` — new: adapter-level fault tests + REST wiring e2e test
 - `backend/tests/test_modbus_fault.py` — added `TestBaseFaultHooks` to assert Modbus inherits no-op base hooks
+- `backend/tests/test_device_simulation_integration.py` — fault roundtrip uses a real device; added 404 + invalid-param (422) tests
 
 ### Verification
-- 320/321 backend tests passed (1 pre-existing regression in `test_device_simulation_integration.test_fault_api_roundtrip` — see caveat above)
-- ruff lint clean
+- Feature suite `test_opcua_fault.py` green every run (real asyncua client round-trips for all 4 fault types, clear→restore+subscription resume, reattach-on-add, live fault-type switch).
+- Full backend suite excluding the OPC UA server test files: **285 passed, 0 failures, 0 errors**. The full suite *including* them is nondeterministic due to a pre-existing asyncpg/event-loop teardown flake (errors only, 0 real failures) — tracked as [#37](https://github.com/kencoolguy/GhostMeter/issues/37).
+- ruff lint clean.
 
 ---
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -29,11 +29,34 @@ This **contradicts issue #37**, which attributed the failure to asyncpg
 `InterfaceError` on the shared event loop. The 6h timeout is the logging flood,
 not asyncpg.
 
+### First (wrong) hypothesis — logging flood
+Initially blamed the ~1100 `asyncua.server.address_space` INFO lines emitted per
+`Server.init()` (root logger at INFO via `app/main.py` basicConfig). Quieted the
+asyncua logger to WARNING and re-ran CI. **It did not fix the timeout**: with the
+flood gone (0 address_space lines confirmed in the CI log), each OPC UA server
+test still took ~680s. The logging happened inside `fill_address_space` but was a
+coincidence, not the cause.
+
+### Real root cause — coverage C-tracer × asyncua's giant module
+CI runs `pytest --cov=app`. Coverage's default C trace function fires per-line on
+ALL modules. asyncua's `create_standard_address_space_Services` lives in a
+~100k-line generated file and runs on every `Server.init()`; each OPC UA server
+test creates a fresh Server, so coverage re-traces the whole address space build.
+Reproduced in a `python:3.12-slim` container (no GHA needed): baseline init()
+= 0.4s; under `coverage run` (default C core) init() did not finish in 240s;
+under `COVERAGE_CORE=sysmon` init() = 0.4s again. The slowness is coverage-
+specific — earlier probes were fast only because they ran without `--cov`.
+
 ### Fix
-One line in `app/main.py` after `basicConfig`:
-`logging.getLogger("asyncua").setLevel(logging.WARNING)`. Confirmed in-container
-that address-space INFO lines drop from 1091 → 0 per init. Fixes production
-startup-log noise too, not just CI.
+`pyproject.toml` `[tool.coverage.run] core = "sysmon"` (PEP 669 sys.monitoring,
+Python 3.12+) — coverage disables instrumentation for non-`source` files, so
+asyncua is no longer traced. The asyncua logger WARNING line stays as a minor
+startup-noise cleanup, but it is NOT the fix.
+
+### Lesson
+The stack dump correctly located the time (inside `fill_address_space`) but the
+visible symptom there (log flood) was not the cause. Should have varied the one
+known difference from the passing local probes — `--cov` — before concluding.
 
 ## 2026-06-03 — OPC UA Comm-layer Fault Simulation
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,40 @@
 # Development Log
 
+## 2026-06-10 — Fix: CI 6h timeout root-caused to asyncua INFO logging
+
+### Problem
+PR #38's backend CI ran the full 6h job limit and was cancelled at ~64%. Every
+OPC UA server test passed but each took ~647s; non-OPC-UA tests were instant.
+
+### Investigation (systematic-debugging)
+- Ruled out, by measurement in a `python:3.12-slim` container: asyncua server
+  lifecycle (~1s), asyncua client connect/disconnect (~0s), asyncpg-after-asyncua
+  on a shared loop (~0s), SQLAlchemy engine-per-loop + asyncua (~0s). None
+  reproduced the 647s — so it was not reproducible outside CI.
+- Instrumented CI on a throwaway branch with `pytest-timeout --timeout=120
+  --timeout-method=thread`. The timeout stack dump landed inside
+  `OpcUaAdapter.start()` → `asyncua.Server.init()` → `load_standard_address_space`
+  → `fill_address_space` → `add_references`, preceded by thousands of
+  `asyncua.server.address_space INFO add_node ...` lines.
+
+### Root cause
+`asyncua` emits ~1100 INFO lines per `Server.init()` (standard address space
+load). `app/main.py` `logging.basicConfig(level=INFO)` sets the root logger to
+INFO; conftest imports `app.main`, so tests inherit it and those INFO records
+are written. ~25 server tests × ~1100 lines, each written to GitHub Actions'
+slow per-line log sink, ballooned each test to ~11 min. Local/probe runs were
+fast because asyncua defaults to WARNING with no app logging config.
+
+This **contradicts issue #37**, which attributed the failure to asyncpg
+`InterfaceError` on the shared event loop. The 6h timeout is the logging flood,
+not asyncpg.
+
+### Fix
+One line in `app/main.py` after `basicConfig`:
+`logging.getLogger("asyncua").setLevel(logging.WARNING)`. Confirmed in-container
+that address-space INFO lines drop from 1091 → 0 per init. Fixes production
+startup-log noise too, not just CI.
+
 ## 2026-06-03 — OPC UA Comm-layer Fault Simulation
 
 ### What was done

--- a/docs/development-phases.md
+++ b/docs/development-phases.md
@@ -242,6 +242,17 @@
 - [x] Post-review hardening: out-of-range value clamping, unique `(#slave_id)` node names, `_device_meta` cleanup
 - [x] Merged to `dev` via PR #33; follow-up PR #34 pinned `pymodbus<3.13`
 
+### Milestone 8.10：OPC UA Comm-layer Fault Simulation ✅ Complete (2026-06-03)
+- [x] `ProtocolAdapter` base gains no-op `apply_fault(device_id)` / `remove_fault(device_id)` hooks; Modbus inherits unchanged (pull-based via trace_pdu)
+- [x] `OpcUaAdapter` overrides hooks: `apply_fault` attaches per-node asyncua value callbacks (`set_attribute_value_callback`); `remove_fault` detaches by re-writing cached value (restores stored value, clears callback, resumes subscriptions atomically)
+- [x] Per-node last-value cache (`_last_values`); `update_register` skips `write_value` while device is in `_faulted` set
+- [x] Fault-type mapping: `exception` → `BadDeviceFailure`, `timeout` → `BadTimeout`, `delay` → bounded server-side `time.sleep` (cap 10 s) + cached value, `intermittent` → random `BadCommunicationError` by `failure_rate`
+- [x] Callback reads `fault_simulator` live on every client read (single source of truth; same model as Modbus trace_pdu)
+- [x] Auto-reattach on `add_device` if a fault is already active (parity with Modbus surviving stop/start)
+- [x] REST `PUT/DELETE /devices/{id}/fault` wired to adapter hook via `get_device_protocol` DB lookup
+- [x] 13 new tests: adapter-level fault tests (exception/timeout/delay/intermittent/cache/subscription restore) + REST e2e round-trip
+- **Note:** SNMP/MQTT adapters could reuse the same base hook pattern in the future (out of scope here; their fault semantics differ significantly)
+
 ### Milestone 8.7：Consolidation (in progress 🔄)
 - [x] Remove VirtualBox shared-folder path hacks from `frontend/package.json` + tsconfigs + `.npmrc`
 - [x] Restore `.github/workflows/ci.yml` (was removed in 6d92a2c pending workflow-scope token)

--- a/docs/superpowers/plans/2026-06-03-opcua-fault-sim.md
+++ b/docs/superpowers/plans/2026-06-03-opcua-fault-sim.md
@@ -1,0 +1,772 @@
+# OPC UA Comm-layer Fault Simulation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the four comm-layer fault types (delay/timeout/exception/intermittent) to the OPC UA adapter, triggered by the existing REST `/fault` endpoint, without touching the Modbus implementation.
+
+**Architecture:** Push-based fault application. A new no-op `apply_fault`/`remove_fault` hook on `ProtocolAdapter` is implemented by the OPC UA adapter to attach/detach per-node value callbacks via `asyncua`'s `set_attribute_value_callback`. The callback polls the existing in-memory `fault_simulator` (single source of truth) on every client read. A per-node last-value cache lets `delay`/`intermittent` serve the latest simulated value; detaching simply re-writes the cached value (which restores the stored value, clears the callback, and resumes subscriptions). The REST endpoint resolves the device's protocol and calls the hook.
+
+**Tech Stack:** Python 3.12, FastAPI, asyncua 1.1.8, pytest + pytest-asyncio, real `asyncua.Client` round-trip tests.
+
+---
+
+## Background the engineer needs
+
+- **Spec:** `docs/superpowers/specs/2026-06-03-opcua-fault-sim-design.md` (read it first).
+- **Fault state** lives in `backend/app/simulation/fault_simulator.py`: module singleton `fault_simulator` with `set_fault(device_id, FaultConfig)`, `clear_fault(device_id)`, `get_fault(device_id) -> FaultConfig | None`, `clear_all()`. `FaultConfig` has `.fault_type: str` and `.params: dict`.
+- **OPC UA adapter:** `backend/app/protocols/opcua_agent.py`. One shared `asyncua.Server`. Per device: an Object node; per register: a Variable node stored in `self._nodes[(device_id, address, function_code)] = node`. Values pushed via `update_register()` → `node.write_value(ua.Variant(...))`. `_TYPE_MAP[data_type] -> (ua.VariantType, caster)`. `_coerce_to_range(value, vtype)` clamps values.
+- **asyncua callback semantics (verified against source):** `server.iserver.aspace.set_attribute_value_callback(nodeid, ua.AttributeIds.Value, cb)` makes reads call `cb(nodeid, attr) -> ua.DataValue` instead of the stored value, and sets the stored value to `None`. There is no API to clear the callback with `None`; instead the normal write path (`node.write_value`) sets the value, clears the callback, and fires subscription notifications. So **while a fault is active, `update_register` must NOT call `write_value`** (it would clear the callback) — it updates the cache only.
+- **Client-side observation of a Bad status without an exception:** `dv = await node.read_data_value(raise_on_bad_status=False)` returns the full `ua.DataValue`; check `dv.StatusCode_.value`. (`read_value()` raises on Bad status.)
+- **Device protocol** is on the template: `template.protocol`. `device_service._get_device_raw(session, id)` returns the device ORM; `device_service.get_template_with_registers(session, template_id)` (alias of `template_service.get_template`) returns the `DeviceTemplate` (has `.protocol`).
+- **Test env (host):** Python 3.12 venv, `pymodbus==3.12.1`, postgres up (`docker compose up -d postgres`), and `DATABASE_URL` overridden to host port 5434. The full command prefix used in every test step below:
+  ```bash
+  cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest
+  ```
+  (Create the venv once if missing: `/opt/homebrew/opt/python@3.12/bin/python3.12 -m venv backend/.venv && ./backend/.venv/bin/python -m pip install -r backend/requirements.txt "pymodbus==3.12.1" ruff`.)
+
+## File structure
+
+- **Modify** `backend/app/protocols/base.py` — add two no-op fault hooks to `ProtocolAdapter`.
+- **Modify** `backend/app/protocols/opcua_agent.py` — cache + `_faulted` state, `apply_fault`/`remove_fault`, value callback, `update_register` skip, lifecycle cleanup/re-attach.
+- **Modify** `backend/app/services/device_service.py` — add `get_device_protocol` helper.
+- **Modify** `backend/app/api/routes/simulation.py` — wire `set_fault`/`clear_fault` to the adapter hook.
+- **Create** `backend/tests/test_opcua_fault.py` — adapter-level + REST-level e2e fault tests.
+- **Modify** `backend/tests/test_modbus_fault.py` — assert the base hooks are inherited no-ops (Modbus untouched).
+- **Modify** docs: `CHANGELOG.md`, `docs/development-log.md`, `docs/development-phases.md`, `docs/api-reference.md`.
+
+---
+
+## Task 1: Base no-op fault hooks
+
+**Files:**
+- Modify: `backend/app/protocols/base.py` (add methods to `ProtocolAdapter`, after `reset_stats`, before the `--- Device lifecycle ---` section)
+- Test: `backend/tests/test_modbus_fault.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/tests/test_modbus_fault.py`:
+
+```python
+class TestBaseFaultHooks:
+    """The base apply_fault/remove_fault hooks are no-ops; Modbus inherits them
+    unchanged (Modbus applies faults via trace_pdu polling, not via these hooks)."""
+
+    @pytest.mark.asyncio
+    async def test_modbus_fault_hooks_are_noops(self):
+        adapter = ModbusTcpAdapter(host="127.0.0.1", port=15598)
+        dev = uuid.uuid4()
+        # No start(), no device registered — pure no-ops must not raise.
+        await adapter.apply_fault(dev)
+        await adapter.remove_fault(dev)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest tests/test_modbus_fault.py::TestBaseFaultHooks -v`
+Expected: FAIL with `AttributeError: 'ModbusTcpAdapter' object has no attribute 'apply_fault'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `backend/app/protocols/base.py`, add to `ProtocolAdapter` immediately after the `reset_stats` method:
+
+```python
+    # --- Fault hooks (concrete no-op default; protocol adapters may override) ---
+
+    async def apply_fault(self, device_id: UUID) -> None:
+        """A comm-layer fault became active for this device.
+
+        Presence toggle only — the active FaultConfig lives in
+        app.simulation.fault_simulator. Default no-op: Modbus polls
+        fault_simulator live in trace_pdu, so it needs no action here.
+        OPC UA overrides this to attach value callbacks.
+        """
+
+    async def remove_fault(self, device_id: UUID) -> None:
+        """The comm-layer fault was cleared for this device. Default no-op."""
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest tests/test_modbus_fault.py::TestBaseFaultHooks -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/protocols/base.py backend/tests/test_modbus_fault.py
+git commit -m "feat: add no-op apply_fault/remove_fault hooks to ProtocolAdapter base"
+```
+
+---
+
+## Task 2: OPC UA last-value cache + `_faulted` state
+
+This adds the per-node value cache and the (still-dormant) `_faulted` set, seeds the cache on device add, maintains it in `update_register` (skipping `write_value` when faulted), and cleans it up on stop/remove. No fault behavior yet — `_faulted` stays empty until Task 3.
+
+**Files:**
+- Modify: `backend/app/protocols/opcua_agent.py`
+- Test: `backend/tests/test_opcua_fault.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_opcua_fault.py`:
+
+```python
+"""Tests for OPC UA comm-layer fault simulation (real asyncua client round-trips)."""
+
+import asyncio
+import socket
+import time
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class TestOpcUaFaultCache:
+    async def test_cache_seeded_on_add_and_updated(self):
+        from app.protocols.base import RegisterInfo
+        from app.protocols.opcua_agent import OpcUaAdapter
+
+        adapter = OpcUaAdapter(host="127.0.0.1", port=_free_port())
+        await adapter.start()
+        dev = uuid.uuid4()
+        regs = [RegisterInfo(0, 3, "float32", "big_endian", name="v")]
+        try:
+            await adapter.add_device(dev, 1, regs)
+            # Seeded with 0 on add
+            assert adapter._last_values[(dev, 0, 3)][0] == 0
+            # Updated by update_register
+            await adapter.update_register(dev, 0, 3, 12.5, "float32", "big_endian")
+            assert abs(adapter._last_values[(dev, 0, 3)][0] - 12.5) < 0.01
+        finally:
+            await adapter.stop()
+
+    async def test_cache_cleared_on_remove_and_stop(self):
+        from app.protocols.base import RegisterInfo
+        from app.protocols.opcua_agent import OpcUaAdapter
+
+        adapter = OpcUaAdapter(host="127.0.0.1", port=_free_port())
+        await adapter.start()
+        dev = uuid.uuid4()
+        regs = [RegisterInfo(0, 3, "float32", "big_endian", name="v")]
+        try:
+            await adapter.add_device(dev, 1, regs)
+            await adapter.remove_device(dev)
+            assert all(k[0] != dev for k in adapter._last_values)
+        finally:
+            await adapter.stop()
+        assert adapter._last_values == {}
+        assert adapter._faulted == set()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest tests/test_opcua_fault.py::TestOpcUaFaultCache -v`
+Expected: FAIL with `AttributeError: 'OpcUaAdapter' object has no attribute '_last_values'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `backend/app/protocols/opcua_agent.py`:
+
+(a) Add to the imports at the top (after `import math`):
+```python
+import random
+import time
+```
+
+(b) In `__init__`, after the `self._device_meta` line, add:
+```python
+        self._last_values: dict[tuple[UUID, int, int], tuple[float | int, ua.VariantType]] = {}
+        self._faulted: set[UUID] = set()  # devices with fault callbacks attached
+```
+
+(c) In `_do_add_device`, in the `for reg in registers:` loop, right after the line `self._nodes[(device_id, reg.address, reg.function_code)] = var`, add:
+```python
+            self._last_values[(device_id, reg.address, reg.function_code)] = (
+                caster(0), vtype,
+            )
+```
+
+(d) Replace the body of `update_register` (everything after the docstring) with:
+```python
+        key = (device_id, address, function_code)
+        node = self._nodes.get(key)
+        if node is None:
+            logger.debug(
+                "OPC UA: no node for device %s addr %d fc %d",
+                device_id, address, function_code,
+            )
+            return
+        vtype, _caster = _TYPE_MAP.get(data_type, (ua.VariantType.Double, float))
+        coerced = _coerce_to_range(value, vtype)
+        self._last_values[key] = (coerced, vtype)
+        if device_id in self._faulted:
+            # Node has a fault value-callback attached; writing would clear it.
+            return
+        await node.write_value(ua.Variant(coerced, vtype))
+```
+
+(e) In `_do_remove_device`, after the `self._nodes = {...}` reassignment, add:
+```python
+        self._last_values = {
+            k: v for k, v in self._last_values.items() if k[0] != device_id
+        }
+        self._faulted.discard(device_id)
+```
+
+(f) In `stop`, alongside the existing `self._nodes.clear()` etc., add:
+```python
+        self._last_values.clear()
+        self._faulted.clear()
+```
+
+- [ ] **Step 4: Run the new test AND the existing OPC UA suite to verify no regression**
+
+Run: `cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest tests/test_opcua_fault.py::TestOpcUaFaultCache tests/test_opcua_adapter.py -v`
+Expected: all PASS (cache tests pass; existing round-trip + subscription tests still pass because `_faulted` is empty, so `update_register` still calls `write_value`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/protocols/opcua_agent.py backend/tests/test_opcua_fault.py
+git commit -m "feat: add OPC UA last-value cache and faulted-device tracking"
+```
+
+---
+
+## Task 3: OPC UA `apply_fault`/`remove_fault` + value callback
+
+This is the core. Attaches per-node value callbacks on `apply_fault`, detaches (restoring values + subscriptions) on `remove_fault`, maps the four fault types to OPC UA semantics, and re-attaches automatically when a device is added while a fault is already active.
+
+**Files:**
+- Modify: `backend/app/protocols/opcua_agent.py`
+- Test: `backend/tests/test_opcua_fault.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/test_opcua_fault.py`:
+
+```python
+class _SubHandler:
+    def __init__(self) -> None:
+        self.values: list = []
+
+    def datachange_notification(self, node, val, data) -> None:  # noqa: ANN001
+        self.values.append(val)
+
+
+async def _make_running_device(port, name="FaultMeter"):
+    """Start an adapter with one device + one float32 register at addr 0/fc 3."""
+    from app.protocols.base import RegisterInfo
+    from app.protocols.opcua_agent import OpcUaAdapter
+
+    adapter = OpcUaAdapter(host="127.0.0.1", port=port)
+    await adapter.start()
+    dev = uuid.uuid4()
+    adapter.set_device_meta(dev, name)
+    await adapter.add_device(dev, 1, [RegisterInfo(0, 3, "float32", "big_endian", name="v")])
+    await adapter.update_register(dev, 0, 3, 100.0, "float32", "big_endian")
+    url = f"opc.tcp://127.0.0.1:{port}/ghostmeter/server/"
+    return adapter, dev, url
+
+
+async def _read_status(url, raise_on_bad=False):
+    """Connect, read the device's 'v' node DataValue, return (status_name, value)."""
+    from asyncua import Client
+
+    async with Client(url=url) as client:
+        ns = await client.get_namespace_index("http://ghostmeter.local/opcua/")
+        gm = await client.nodes.objects.get_child([f"{ns}:GhostMeter"])
+        dev = await gm.get_child([f"{ns}:FaultMeter (#1)"])
+        var = await dev.get_child([f"{ns}:v"])
+        dv = await var.read_data_value(raise_on_bad_status=raise_on_bad)
+        return dv.StatusCode_.name, (dv.Value.Value if dv.Value else None)
+
+
+class TestOpcUaFaultApplication:
+    async def test_exception_fault_yields_bad_device_failure(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            await adapter.apply_fault(dev)
+            status, _ = await _read_status(url)
+            assert status == "BadDeviceFailure", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_timeout_fault_yields_bad_timeout(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("timeout", {}))
+            await adapter.apply_fault(dev)
+            status, _ = await _read_status(url)
+            assert status == "BadTimeout", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_delay_fault_slows_reads(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("delay", {"delay_ms": 400}))
+            await adapter.apply_fault(dev)
+            t0 = time.monotonic()
+            status, value = await _read_status(url, raise_on_bad=True)
+            elapsed = time.monotonic() - t0
+            assert status == "Good", status
+            assert abs(value - 100.0) < 0.01
+            assert elapsed >= 0.3, f"expected >=0.3s, got {elapsed:.3f}s"
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_intermittent_rate_1_always_bad(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("intermittent", {"failure_rate": 1.0}))
+            await adapter.apply_fault(dev)
+            for _ in range(3):
+                status, _ = await _read_status(url)
+                assert status == "BadCommunicationError", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_intermittent_rate_0_always_good(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("intermittent", {"failure_rate": 0.0}))
+            await adapter.apply_fault(dev)
+            status, value = await _read_status(url, raise_on_bad=True)
+            assert status == "Good"
+            assert abs(value - 100.0) < 0.01
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_update_register_during_fault_does_not_clear_callback(self):
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            await adapter.apply_fault(dev)
+            # Simulation engine keeps pushing values during the fault:
+            await adapter.update_register(dev, 0, 3, 222.0, "float32", "big_endian")
+            status, _ = await _read_status(url)
+            assert status == "BadDeviceFailure", status  # callback still active
+            # but the cache tracked the latest value
+            assert abs(adapter._last_values[(dev, 0, 3)][0] - 222.0) < 0.01
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_clear_fault_restores_value_and_subscription(self):
+        from asyncua import Client
+
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter, dev, url = await _make_running_device(port)
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            await adapter.apply_fault(dev)
+            # clear
+            fault_simulator.clear_fault(dev)
+            await adapter.remove_fault(dev)
+
+            async with Client(url=url) as client:
+                ns = await client.get_namespace_index("http://ghostmeter.local/opcua/")
+                gm = await client.nodes.objects.get_child([f"{ns}:GhostMeter"])
+                d = await gm.get_child([f"{ns}:FaultMeter (#1)"])
+                var = await d.get_child([f"{ns}:v"])
+                # value readable again (the cached 100.0)
+                assert abs(await var.read_value() - 100.0) < 0.01
+                # subscription resumes
+                handler = _SubHandler()
+                sub = await client.create_subscription(50, handler)
+                await sub.subscribe_data_change(var)
+                await asyncio.sleep(0.3)
+                await adapter.update_register(dev, 0, 3, 175.0, "float32", "big_endian")
+                await asyncio.sleep(0.5)
+                await sub.delete()
+                assert any(abs(v - 175.0) < 0.05 for v in handler.values), handler.values
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+
+    async def test_fault_reattaches_on_device_add(self):
+        """A fault set before the device is added is re-applied on add (parity with
+        Modbus, where the fault survives a device stop/start)."""
+        from app.protocols.base import RegisterInfo
+        from app.protocols.opcua_agent import OpcUaAdapter
+        from app.simulation import fault_simulator
+        from app.simulation.fault_simulator import FaultConfig
+
+        port = _free_port()
+        adapter = OpcUaAdapter(host="127.0.0.1", port=port)
+        await adapter.start()
+        dev = uuid.uuid4()
+        try:
+            fault_simulator.set_fault(dev, FaultConfig("exception", {}))
+            adapter.set_device_meta(dev, "FaultMeter")
+            await adapter.add_device(dev, 1, [RegisterInfo(0, 3, "float32", "big_endian", name="v")])
+            assert dev in adapter._faulted
+            url = f"opc.tcp://127.0.0.1:{port}/ghostmeter/server/"
+            status, _ = await _read_status(url)
+            assert status == "BadDeviceFailure", status
+        finally:
+            fault_simulator.clear_all()
+            await adapter.stop()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest tests/test_opcua_fault.py::TestOpcUaFaultApplication -v`
+Expected: FAIL (e.g. `AttributeError: 'OpcUaAdapter' object has no attribute 'apply_fault'`, or callbacks not applied so status is `Good`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `backend/app/protocols/opcua_agent.py`, add these methods to `OpcUaAdapter` (place them after `update_register`, before `set_device_meta`):
+
+```python
+    # --- Fault application (overrides base no-op) ---
+
+    def _bad_datavalue(self, status_code: int) -> "ua.DataValue":
+        """Build a DataValue carrying a Bad StatusCode (no value)."""
+        dv = ua.DataValue()
+        dv.StatusCode_ = ua.StatusCode(status_code)
+        return dv
+
+    def _good_datavalue(self, key: tuple[UUID, int, int]) -> "ua.DataValue":
+        """Build a Good DataValue from the latest cached value for a node."""
+        value, vtype = self._last_values.get(key, (0, ua.VariantType.Double))
+        return ua.DataValue(ua.Variant(value, vtype))
+
+    def _make_fault_callback(self, device_id: UUID, key: tuple[UUID, int, int]):
+        """Create the synchronous value callback asyncua calls on every read.
+
+        Reads fault_simulator live so it reflects the current fault type/params
+        (single source of truth, same model as Modbus trace_pdu).
+        """
+        from app.simulation import fault_simulator
+
+        def cb(nodeid, attr):  # noqa: ANN001 — asyncua calls cb(nodeid, attr)
+            fault = fault_simulator.get_fault(device_id)
+            if fault is None:
+                return self._good_datavalue(key)
+            ftype = fault.fault_type
+            if ftype == "exception":
+                return self._bad_datavalue(ua.StatusCodes.BadDeviceFailure)
+            if ftype == "timeout":
+                return self._bad_datavalue(ua.StatusCodes.BadTimeout)
+            if ftype == "delay":
+                delay_ms = min(int(fault.params.get("delay_ms", 500)), 10000)
+                time.sleep(delay_ms / 1000.0)  # bounded blocking (mirrors Modbus)
+                return self._good_datavalue(key)
+            if ftype == "intermittent":
+                rate = float(fault.params.get("failure_rate", 0.5))
+                if random.random() < rate:
+                    return self._bad_datavalue(ua.StatusCodes.BadCommunicationError)
+                return self._good_datavalue(key)
+            return self._good_datavalue(key)  # unknown type → behave normally
+
+        return cb
+
+    async def apply_fault(self, device_id: UUID) -> None:
+        """Attach a value callback to each of the device's nodes (idempotent)."""
+        if self._server is None or device_id in self._faulted:
+            return
+        aspace = self._server.iserver.aspace
+        for key, node in list(self._nodes.items()):
+            if key[0] != device_id:
+                continue
+            cb = self._make_fault_callback(device_id, key)
+            aspace.set_attribute_value_callback(node.nodeid, ua.AttributeIds.Value, cb)
+        self._faulted.add(device_id)
+        logger.info("OPC UA: fault callbacks attached for device %s", device_id)
+
+    async def remove_fault(self, device_id: UUID) -> None:
+        """Detach callbacks by re-writing cached values (restores value +
+        clears callback + resumes subscriptions in one write)."""
+        if device_id not in self._faulted:
+            return
+        for key, node in list(self._nodes.items()):
+            if key[0] != device_id:
+                continue
+            value, vtype = self._last_values.get(key, (0, ua.VariantType.Double))
+            try:
+                await node.write_value(ua.Variant(value, vtype))
+            except Exception:
+                logger.debug("OPC UA: error restoring node after fault clear", exc_info=True)
+        self._faulted.discard(device_id)
+        logger.info("OPC UA: fault callbacks removed for device %s", device_id)
+```
+
+Then, at the END of `_do_add_device` (after the existing `logger.info("OPC UA: added device ...")` call), add the re-attach check:
+
+```python
+        from app.simulation import fault_simulator
+        if fault_simulator.get_fault(device_id) is not None:
+            await self.apply_fault(device_id)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest tests/test_opcua_fault.py tests/test_opcua_adapter.py -v`
+Expected: all PASS (new fault tests pass; existing adapter/subscription tests still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/protocols/opcua_agent.py backend/tests/test_opcua_fault.py
+git commit -m "feat: implement OPC UA comm-layer fault application via value callbacks"
+```
+
+---
+
+## Task 4: REST wiring (`set_fault`/`clear_fault` → adapter hook)
+
+**Files:**
+- Modify: `backend/app/services/device_service.py` (add `get_device_protocol`)
+- Modify: `backend/app/api/routes/simulation.py`
+- Test: `backend/tests/test_opcua_fault.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_opcua_fault.py`:
+
+```python
+class TestOpcUaFaultRestWiring:
+    async def test_put_fault_applies_to_opcua_then_delete_clears(self, client):
+        from asyncua import Client
+
+        from app.protocols import protocol_manager
+        from app.protocols.opcua_agent import OpcUaAdapter
+        from app.simulation import fault_simulator
+
+        port = _free_port()
+        adapter = OpcUaAdapter(host="127.0.0.1", port=port)
+        protocol_manager.register_adapter("opcua", adapter)
+        await protocol_manager.start_all()
+        try:
+            tpl = await client.post("/api/v1/templates", json={
+                "name": "Fault-OPCUA",
+                "protocol": "opcua",
+                "registers": [
+                    {"name": "v", "address": 0, "function_code": 3,
+                     "data_type": "float32", "byte_order": "big_endian",
+                     "scale_factor": 1.0, "unit": "V", "sort_order": 0},
+                ],
+            })
+            assert tpl.status_code == 201
+            template_id = tpl.json()["data"]["id"]
+
+            dev = await client.post("/api/v1/devices", json={
+                "name": "RestFaultMeter", "template_id": template_id,
+                "slave_id": 1, "port": 4840,
+            })
+            assert dev.status_code == 201
+            device_id = dev.json()["data"]["id"]
+            assert (await client.post(f"/api/v1/devices/{device_id}/start")).status_code == 200
+
+            url = f"opc.tcp://127.0.0.1:{port}/ghostmeter/server/"
+
+            async def read_status():
+                async with Client(url=url) as opc:
+                    ns = await opc.get_namespace_index("http://ghostmeter.local/opcua/")
+                    gm = await opc.nodes.objects.get_child([f"{ns}:GhostMeter"])
+                    d = await gm.get_child([f"{ns}:RestFaultMeter (#1)"])
+                    var = await d.get_child([f"{ns}:v"])
+                    dv = await var.read_data_value(raise_on_bad_status=False)
+                    return dv.StatusCode_.name
+
+            # PUT fault → OPC UA reads go Bad
+            put = await client.put(
+                f"/api/v1/devices/{device_id}/fault",
+                json={"fault_type": "exception", "params": {}},
+            )
+            assert put.status_code == 200
+            assert await read_status() == "BadDeviceFailure"
+
+            # DELETE fault → reads recover
+            assert (await client.delete(f"/api/v1/devices/{device_id}/fault")).status_code == 200
+            assert await read_status() == "Good"
+        finally:
+            fault_simulator.clear_all()
+            await protocol_manager.stop_all()
+            protocol_manager._adapters.pop("opcua", None)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest tests/test_opcua_fault.py::TestOpcUaFaultRestWiring -v`
+Expected: FAIL — after PUT, status is still `Good` because the REST endpoint does not yet call `apply_fault`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+(a) In `backend/app/services/device_service.py`, add this helper after `_get_device_raw`:
+
+```python
+async def get_device_protocol(
+    session: AsyncSession, device_id: uuid.UUID,
+) -> str:
+    """Resolve a device's protocol via its template. Raises 404 if absent."""
+    device = await _get_device_raw(session, device_id)
+    template = await get_template_with_registers(session, device.template_id)
+    return template.protocol
+```
+
+(b) In `backend/app/api/routes/simulation.py`, add imports near the existing ones:
+
+```python
+from app.protocols import protocol_manager
+from app.services import device_service
+```
+
+(c) Replace the `set_fault` handler body and signature with:
+
+```python
+async def set_fault(
+    device_id: uuid.UUID,
+    data: FaultConfigSet,
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[FaultConfigResponse]:
+    """Set a communication fault on a device (in-memory) and apply it to the adapter."""
+    fault = FaultConfig(fault_type=data.fault_type, params=data.params)
+    fault_simulator.set_fault(device_id, fault)
+
+    protocol = await device_service.get_device_protocol(session, device_id)
+    adapter = protocol_manager.get_adapter(protocol)
+    if adapter is not None and protocol_manager.is_running:
+        await adapter.apply_fault(device_id)
+
+    monitor_service.log_event(
+        device_id, str(device_id), "fault_set",
+        f"Fault set: {data.fault_type}",
+    )
+    return ApiResponse(
+        data=FaultConfigResponse(
+            fault_type=fault.fault_type,
+            params=fault.params,
+        )
+    )
+```
+
+(d) Replace the `clear_fault` handler body and signature with:
+
+```python
+async def clear_fault(
+    device_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[None]:
+    """Clear the active fault for a device and detach it from the adapter."""
+    fault_simulator.clear_fault(device_id)
+
+    protocol = await device_service.get_device_protocol(session, device_id)
+    adapter = protocol_manager.get_adapter(protocol)
+    if adapter is not None and protocol_manager.is_running:
+        await adapter.remove_fault(device_id)
+
+    monitor_service.log_event(
+        device_id, str(device_id), "fault_clear", "Fault cleared",
+    )
+    return ApiResponse(message="Fault cleared successfully")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest tests/test_opcua_fault.py::TestOpcUaFaultRestWiring -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/device_service.py backend/app/api/routes/simulation.py backend/tests/test_opcua_fault.py
+git commit -m "feat: wire REST fault set/clear to OPC UA adapter via apply_fault/remove_fault"
+```
+
+---
+
+## Task 5: Full suite, lint, and docs
+
+**Files:**
+- Modify: `CHANGELOG.md`, `docs/development-log.md`, `docs/development-phases.md`, `docs/api-reference.md`
+
+- [ ] **Step 1: Run the full backend suite + lint**
+
+Run:
+```bash
+cd backend && DATABASE_URL="postgresql+asyncpg://ghostmeter:ghostmeter@localhost:5434/ghostmeter" ./.venv/bin/python -m pytest -q
+./.venv/bin/ruff check app tests
+```
+Expected: all tests PASS, ruff clean. Fix any failures before continuing. (If `ruff` flags the new `import random`/`import time` ordering, run `./.venv/bin/ruff check --fix app tests`.)
+
+- [ ] **Step 2: Update `CHANGELOG.md`**
+
+Under `## [Unreleased]`, add to the appropriate `### Added` list:
+```markdown
+- OPC UA comm-layer fault simulation: delay / timeout / exception / intermittent now
+  apply to OPC UA devices via per-node value callbacks (push-based; attaches on fault set,
+  detaches on clear). Modbus behavior unchanged.
+```
+
+- [ ] **Step 3: Update `docs/development-log.md`**
+
+Add a dated entry summarizing: the asyncua value-callback constraint (callback replaces stored reads + clears stored value; detach via re-write), why the design is push-based, the per-node cache, the base `apply_fault`/`remove_fault` hook, REST wiring, and the bounded-blocking `delay` caveat.
+
+- [ ] **Step 4: Update `docs/development-phases.md`**
+
+Mark the OPC UA fault-simulation milestone status (In Progress → Complete) and note next steps (SNMP/MQTT could reuse the base hook pattern; out of scope here).
+
+- [ ] **Step 5: Update `docs/api-reference.md`**
+
+For `PUT/DELETE /devices/{id}/fault`, add a note that for OPC UA devices the fault is applied at the protocol layer: `exception` → `BadDeviceFailure`, `timeout` → `BadTimeout`, `delay` → bounded server-side sleep, `intermittent` → random `BadCommunicationError` by `failure_rate`. No request/response schema change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CHANGELOG.md docs/development-log.md docs/development-phases.md docs/api-reference.md
+git commit -m "docs: document OPC UA comm-layer fault simulation"
+```
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Modbus untouched:** only `base.py` gains two no-op methods; `modbus_tcp.py` is not modified. Task 1's test proves Modbus inherits no-ops.
+- **Subscription safety:** `update_register` only skips `write_value` while `device_id in self._faulted`; outside a fault it behaves exactly as before, so existing subscription tests must keep passing (verified in Tasks 2 & 3 Step 4).
+- **Single source of truth:** the callback reads `fault_simulator.get_fault` live; the base hook is a presence toggle only.
+- **Cleanup:** every test that calls `fault_simulator.set_fault` must `fault_simulator.clear_all()` in `finally` to avoid leaking fault state across tests (the simulator is a module singleton).

--- a/docs/superpowers/specs/2026-06-03-opcua-fault-sim-design.md
+++ b/docs/superpowers/specs/2026-06-03-opcua-fault-sim-design.md
@@ -1,0 +1,224 @@
+# OPC UA Comm-layer Fault Simulation — Design Spec
+
+- **Date:** 2026-06-03
+- **Status:** Approved (brainstorming complete) — ready for implementation plan
+- **Branch:** `feature/claude-opcua-fault-sim-20260603`
+- **Scope label:** B-light (OPC UA only; lightly generalized so SNMP can adopt later)
+
+## 1. Goal
+
+Comm-layer fault injection (delay / timeout / exception / intermittent) is GhostMeter's
+core selling point but currently exists **only on Modbus**. SNMP, MQTT, and OPC UA have
+value-level anomaly injection only. This work brings all four fault types to the **OPC UA**
+adapter, reusing the existing protocol-agnostic fault state and REST API, and leaving the
+Modbus implementation untouched.
+
+### Success criteria
+
+A real `asyncua` client connecting to the GhostMeter OPC UA server observes:
+
+- `exception` → reads return a Bad status code (`BadDeviceFailure`)
+- `timeout` → reads return `BadTimeout`
+- `delay` → reads measurably slower (bounded)
+- `intermittent` → reads alternate Bad / Good per `failure_rate`
+- after `clear` → reads return normal values again **and subscriptions resume**
+
+## 2. Background — current state (verified against code 2026-06-03)
+
+- **Fault state is protocol-agnostic and in-memory.** `app/simulation/fault_simulator.py`
+  holds `FaultConfig(fault_type, params)` per device via the module singleton
+  `fault_simulator` (`set_fault` / `clear_fault` / `get_fault` / `clear_all`).
+- **REST `/devices/{id}/fault` (PUT/GET/DELETE)** in `app/api/routes/simulation.py` only
+  mutates `fault_simulator` and writes an activity-log event. It does **not** touch any
+  adapter today.
+- **Modbus is pull-based.** `modbus_tcp.py` `_create_trace_pdu` polls
+  `fault_simulator.get_fault(dev_id)` on every PDU and applies the fault there. That is why
+  Modbus needs no adapter wiring at fault set/clear, and why a fault survives a device
+  restart automatically.
+- **OPC UA adapter** (`opcua_agent.py`) is a single shared `asyncua.Server`. Each device is
+  an Object node; each register a read-only Variable node. The simulation engine pushes
+  values via `update_register()` → `node.write_value(...)`, and asyncua delivers
+  subscription notifications on value change (covered by an existing test).
+- **A device's protocol lives on its `template` (`template.protocol`)**, not on the device
+  row. `device_service.start_device` calls `protocol_manager.add_device(template.protocol, …)`
+  and `stop_device` calls `remove_device` (nodes are deleted on stop, recreated on start).
+- **Frontend** `pages/Simulation/FaultTab.tsx` has no protocol gating — the fault panel is
+  already shown for OPC UA devices. Frontend work here is verification, not development.
+
+## 3. Binding constraint discovered (asyncua value callbacks)
+
+The OPC UA injection hook is a per-node value callback:
+`server.iserver.aspace.set_attribute_value_callback(nodeid, ua.AttributeIds.Value, cb)`,
+where `cb(nodeid, attr) -> ua.DataValue` is invoked on **every** client read
+(spike-verified live on asyncua 1.1.8).
+
+Reading the asyncua `address_space.py` source established the exact semantics:
+
+1. When a value callback is set, reads call the callback **instead of** the stored value.
+2. `set_attribute_value_callback` sets `attval.value = None` and `attval.value_callback = cb`.
+   It does **not** accept `callback=None` to clear, and has no value-seed parameter.
+3. While a callback is set, the normal write path would **overwrite/clear** it.
+4. `write_attribute_value` (i.e. the normal `node.write_value()` path) sets
+   `attval.value = value`, sets `attval.value_callback = None`, **and** fires the
+   `datachange_callbacks` (subscription notifications).
+
+### Consequences (these drive the design)
+
+- A **permanent / pull-style callback is out** — it would clear the stored value, break
+  `update_register`'s writes, and silence subscriptions (a tested feature). Fault
+  application must be **push-based: attach the callback only while a fault is active.**
+- **Detach is trivial:** calling `node.write_value(cached_value)` simultaneously restores
+  the stored value, clears the fault callback, and resumes subscriptions. No special API.
+- During an active fault, `update_register` **must not** call `write_value` (it would clear
+  the callback and silently remove the fault). It must update a cache only.
+- For `delay` and `intermittent`-good reads the callback must return the **current
+  simulated value**; since the stored value is unavailable while a callback is set, the
+  adapter keeps its own per-node last-value cache.
+
+## 4. Architecture decision
+
+**Approach A — base hook + explicit REST trigger** (chosen over an update-loop self-trigger
+alternative for immediacy, explicit data flow, and SNMP reuse).
+
+- `fault_simulator` remains the **single source of truth**; the OPC UA callback polls it
+  live on each read (same model as Modbus `trace_pdu`).
+- A new base hook is a **presence toggle** only ("this device now has / no longer has a
+  fault — attach/detach callbacks"). It carries no `FaultConfig`, so `base.py` stays
+  decoupled from the simulation layer.
+
+## 5. Detailed design
+
+### 5.1 Base hook — `app/protocols/base.py`
+
+Add two methods to `ProtocolAdapter`, both default no-op:
+
+```python
+async def apply_fault(self, device_id: UUID) -> None:
+    """A fault became active for this device. Default no-op.
+
+    Modbus polls fault_simulator live in trace_pdu, so it needs no action here.
+    """
+
+async def remove_fault(self, device_id: UUID) -> None:
+    """The fault was cleared for this device. Default no-op."""
+```
+
+Modbus inherits both no-ops; its behavior is unchanged.
+
+### 5.2 OPC UA adapter — `app/protocols/opcua_agent.py`
+
+New state:
+
+- `_last_values: dict[tuple[UUID, int, int], tuple[float | int, ua.VariantType]]`
+  — updated on every `update_register`; seeded with `(0, vtype)` per node in
+  `_do_add_device` so the callback always has a value to serve.
+- `_faulted: set[UUID]` — devices whose nodes currently have a fault callback attached.
+
+Behavior:
+
+- **`update_register`**: always update `_last_values`. If `device_id in _faulted`, **skip**
+  `write_value` (it would clear the callback); otherwise `write_value` as today.
+- **`apply_fault(device_id)`** (idempotent — return early if already in `_faulted`): for each
+  node of the device call
+  `self._server.iserver.aspace.set_attribute_value_callback(node.nodeid, ua.AttributeIds.Value, cb)`;
+  add to `_faulted`.
+- **`remove_fault(device_id)`** (no-op if not in `_faulted`): for each node call
+  `await node.write_value(<cached value as Variant>)` to restore value + clear callback +
+  resume subscriptions; remove from `_faulted`.
+- **callback `cb(nodeid, attr) -> ua.DataValue`** (synchronous, per asyncua contract):
+  - `f = fault_simulator.get_fault(device_id)`
+  - `f is None` → return cached Good `DataValue` (defensive; shouldn't happen while attached)
+  - dispatch on `f.fault_type` (see §5.3)
+- **Lifecycle:**
+  - `_do_add_device`: after creating nodes + seeding cache, if
+    `fault_simulator.get_fault(device_id)` is set, call `apply_fault(device_id)` — so a fault
+    survives a device stop/start, matching Modbus.
+  - `_do_remove_device`: drop the device's entries from `_last_values` and `_faulted`
+    (callbacks die with the deleted nodes).
+  - `stop`: also clear `_last_values` and `_faulted` (alongside the existing map clears).
+
+### 5.3 Fault-type → OPC UA mapping
+
+| Modbus semantics | OPC UA implementation |
+|---|---|
+| `exception` | return `DataValue(status=BadDeviceFailure)` (fixed for MVP; param-overridable later) |
+| `timeout` | return `DataValue(status=BadTimeout)` — shared single server can't drop one device's response, so a Bad status is the idiomatic representation |
+| `delay` | `time.sleep(min(params.delay_ms (default 500), 10000) / 1000)`, then return cached Good value |
+| `intermittent` | `random.random() < params.failure_rate (default 0.5)` → return `BadCommunicationError`; else cached Good value |
+
+DataValue construction for Bad status follows the spike-verified pattern (a `DataValue`
+carrying the Bad `StatusCode` makes the client read raise that status). Good values are
+returned as `ua.DataValue(ua.Variant(value, vtype))`.
+
+### 5.4 REST wiring — `app/api/routes/simulation.py`
+
+- `set_fault`: add the DB `session` dependency. After `fault_simulator.set_fault(...)`,
+  resolve the device's `template.protocol` (as `device_service` does), get the adapter via
+  `protocol_manager.get_adapter(protocol)`, and if present + running call
+  `await adapter.apply_fault(device_id)`.
+- `clear_fault`: symmetric — after `fault_simulator.clear_fault(...)`, call
+  `await adapter.remove_fault(device_id)`.
+- Modbus adapters run the inherited no-ops, so their REST behavior is unchanged.
+- Keep the existing activity-log events.
+
+## 6. Edge cases & lifecycle
+
+- **Fault set then device stopped:** `fault_simulator` keeps the fault; `remove_device`
+  deletes nodes/callbacks and cleans adapter caches. On `start_device` → `_do_add_device`
+  re-attaches the callback (§5.2 lifecycle), so the fault resumes — consistent with Modbus.
+- **Backend restart:** `fault_simulator` is in-memory and is wiped, so faults do not survive
+  a backend restart (same as Modbus). Acceptable.
+- **Replace an active fault** (set_fault called again with a new type/params): callback reads
+  `fault_simulator` live, so the new config applies immediately; `apply_fault` is idempotent.
+- **Cache cold** (fault set before first `update_register`): seeded `(0, vtype)` in
+  `_do_add_device` guarantees a serveable value.
+
+## 7. Caveats (to document)
+
+- **`delay` blocks the event loop:** the value callback is synchronous, so `time.sleep`
+  briefly blocks the shared backend event loop (affecting all OPC UA reads). This mirrors
+  Modbus `trace_pdu`'s existing `time.sleep`. Bounded at 10s; bounded blocking accepted. A
+  truly non-blocking delay is out of scope.
+- **`timeout` is represented as a Bad status, not a real dropped connection** — a limitation
+  of the shared single-session server.
+
+## 8. Testing (real end-to-end)
+
+Run on the host per the documented env: Python 3.12 venv,
+`pymodbus==3.12.1`, `DATABASE_URL=…@localhost:5434/ghostmeter`, postgres up via
+`docker compose up -d postgres`.
+
+- **Integration (real client round-trip):** start the OPC UA server, add a device, connect
+  a real `asyncua` client, then for each fault type assert the §1 success criteria,
+  including that `clear` restores normal reads and a subscription fires again afterward.
+- **Adapter unit tests:** `apply_fault`/`remove_fault` attach/detach correctly; callback
+  returns the right `DataValue`/status per type; `_last_values` cache is maintained;
+  `update_register` does not clobber the callback while faulted; re-attach on
+  `_do_add_device` when a fault is already active.
+
+## 9. Out of scope
+
+- SNMP / MQTT fault application (the base-hook pattern is reusable, but not implemented here).
+- Any change to the Modbus implementation.
+- True connection-level drop for `timeout`.
+- Perfect non-blocking `delay`.
+
+## 10. Docs to update on push
+
+- `CHANGELOG.md` — new OPC UA fault simulation entry.
+- `docs/development-log.md` — what/why/decisions/asyncua constraint.
+- `docs/development-phases.md` — mark this milestone in progress → complete.
+- `docs/api-reference.md` — note OPC UA semantics for `/devices/{id}/fault` (no schema change).
+- `docs/database-schema.md` — no change (faults are in-memory).
+
+## 11. Implementation order (small, compilable, testable steps)
+
+1. Add `apply_fault` / `remove_fault` no-op hooks to `ProtocolAdapter` base.
+2. OPC UA adapter: add `_last_values` + `_faulted` state; seed cache in `_do_add_device`;
+   maintain cache in `update_register` (skip `write_value` while faulted); clear in
+   `stop` / `_do_remove_device`.
+3. OPC UA adapter: implement `apply_fault` / `remove_fault` + the value callback with the
+   §5.3 fault mapping; re-attach in `_do_add_device` when a fault is already active.
+4. Wire REST `set_fault` / `clear_fault` to resolve protocol and call the hooks.
+5. Adapter unit tests, then real e2e integration tests.
+6. Update docs (§10).


### PR DESCRIPTION
## Summary
Brings the four comm-layer fault types (**delay / timeout / exception / intermittent**) to the **OPC UA** adapter, triggered by the existing `PUT/DELETE /api/v1/devices/{id}/fault` endpoints. The Modbus implementation is left entirely untouched.

Previously fault injection — GhostMeter's core selling point — existed only on Modbus; SNMP/MQTT/OPC UA had value-level anomaly injection but no comm-layer faults.

## How it works (push-based)
- `ProtocolAdapter` gains no-op `apply_fault(device_id)` / `remove_fault(device_id)` hooks. Modbus inherits the no-ops (it still applies faults via `trace_pdu` polling — pull-based, unchanged).
- `OpcUaAdapter` implements the hooks by attaching/detaching per-node **asyncua value callbacks** (`set_attribute_value_callback`). The callback reads `fault_simulator` **live** on every client read — same single-source-of-truth model as Modbus.
- A per-node last-value cache lets `delay`/`intermittent` serve the latest simulated value; while faulted, `update_register` updates the cache but skips `write_value` (which would clear the callback). `remove_fault` re-writes the cached value, which atomically restores the value, clears the callback, and **resumes OPC UA subscriptions**.
- A fault re-attaches automatically on device add (parity with Modbus surviving a device stop/start).
- REST `set_fault`/`clear_fault` resolve the device's protocol (via its template) and call the hook; the device is validated before any state mutation (404 on unknown device, no orphan state).

## Fault → OPC UA mapping
| type | result |
|---|---|
| `exception` | `BadDeviceFailure` status |
| `timeout` | `BadTimeout` status |
| `delay` | bounded `time.sleep` (≤10s) then cached value |
| `intermittent` | random `BadCommunicationError` by `failure_rate` |

Fault params are validated at the schema layer (`delay_ms` int ≥ 0; `failure_rate` ∈ [0,1]) → clean 422 instead of a deep `BadInternalError`.

## Test Plan
- [x] Real `asyncua` client round-trips for all 4 fault types
- [x] `clear` restores normal reads **and** subscriptions resume
- [x] re-attach on device add; live fault-type switch without re-apply
- [x] `update_register` during a fault does not clear the callback
- [x] REST e2e: `PUT` → Bad status, `DELETE` → recovered; 404 on unknown device; 422 on bad params
- [x] Modbus inherits no-op hooks (path unchanged)
- [x] ruff clean; feature suite green; full suite excluding the OPC UA server tests: 285 passed, 0 failures

## Known follow-up
- #37 — pre-existing nondeterministic test-infra flake (`asyncpg.InterfaceError` in DB-fixture teardown when OPC UA server tests share the event loop). Errors only, **0 real failures**; aggravated by the added server tests. Tracked separately, does not affect production or feature correctness.

## Docs
CHANGELOG, development-log, development-phases (Milestone 8.10), api-reference updated. No DB schema change (faults are in-memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)