### PR TITLE
feat: Linode deployment tooling (prod overlay + deploy.sh)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,9 @@ OPCUA_NAMESPACE_URI=http://ghostmeter.local/opcua/
 
 # Frontend
 VITE_API_BASE_URL=http://localhost:8000
+
+# Deployment (only used by docker-compose.prod.yml / deploy.sh)
+# Bind address for published ports on an exposed host. Set to this machine's
+# Tailscale IP so services are reachable over the tailnet but NOT the public
+# Internet. Leave empty for local dev (defaults to 127.0.0.1).
+BIND_IP=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Deployment tooling for exposed hosts: `docker-compose.prod.yml` overlay binds all published ports to `BIND_IP` (Tailscale IP) and stops publishing PostgreSQL, so nothing is exposed on the public network interface
+- `deploy.sh` one-shot deploy script (applies prod overlay, runs Alembic migrations before startup, brings services up)
+- `docs/deployment.md` — concise Linode deployment guide (Tailscale + Cloudflare Tunnel)
+- `.env.example`: new `BIND_IP` setting (defaults to 127.0.0.1 when unset, failing safe to local-only)
 - OPC UA server adapter: exposes simulated devices as browsable Variable nodes (Read + Subscribe, Anonymous + SecurityPolicy None) via asyncua
 - Built-in "Energy Meter (OPC UA)" template (11 registers) + Normal Operation profile
 - OPC UA protocol option in template creation

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# GhostMeter deploy helper.
+#
+# Always applies docker-compose.prod.yml so published ports stay bound to
+# BIND_IP (never the public network interface), and always runs database
+# migrations before bringing the app up — the app only seeds data on startup,
+# it does NOT create tables, so skipping migrations breaks a fresh deploy.
+#
+# Usage (from the repo root, on the deploy host):
+#   ./deploy.sh
+#
+# Prerequisites:
+#   - .env exists (cp .env.example .env, then set POSTGRES_PASSWORD + BIND_IP)
+#   - Docker + Docker Compose v2.24.0+ installed
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -f .env ]; then
+  echo "ERROR: .env not found. Run: cp .env.example .env  then edit it." >&2
+  exit 1
+fi
+
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.prod.yml)
+
+echo "==> Building backend and frontend images"
+"${COMPOSE[@]}" build backend frontend
+
+echo "==> Starting postgres"
+"${COMPOSE[@]}" up -d postgres
+
+echo "==> Waiting for postgres to become healthy"
+until [ "$(docker inspect -f '{{.State.Health.Status}}' ghostmeter-postgres 2>/dev/null)" = "healthy" ]; do
+  sleep 2
+done
+
+echo "==> Running database migrations (alembic upgrade head)"
+"${COMPOSE[@]}" run --rm backend alembic upgrade head
+
+echo "==> Starting all services"
+"${COMPOSE[@]}" up -d
+
+echo "==> Current status"
+"${COMPOSE[@]}" ps

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,31 @@
+# Production overlay for exposed hosts (e.g. a public Linode VM).
+#
+# Apply it ON TOP of the base file — order matters:
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+# Easier: just run ./deploy.sh, which bakes in both -f flags.
+#
+# Purpose: never publish service ports on the public network interface.
+#   - Every port is bound to BIND_IP (set this to the host's Tailscale IP in
+#     .env). Reachable over the tailnet, invisible from the public Internet.
+#   - PostgreSQL is not published at all — backend reaches it over the internal
+#     compose network (postgres:5432).
+#   - !override replaces the base port list instead of merging with it
+#     (merging would KEEP the public 0.0.0.0 bindings — defeating the point).
+#     Requires Docker Compose v2.24.0+.
+#
+# BIND_IP defaults to 127.0.0.1 (loopback) when unset, so a missing value
+# fails safe to "local only" rather than exposing everything publicly.
+services:
+  postgres:
+    ports: !override []
+
+  backend:
+    ports: !override
+      - "${BIND_IP:-127.0.0.1}:8000:8000"
+      - "${BIND_IP:-127.0.0.1}:502:502"
+      - "${BIND_IP:-127.0.0.1}:4840:4840"
+      - "${BIND_IP:-127.0.0.1}:161:10161/udp"
+
+  frontend:
+    ports: !override
+      - "${BIND_IP:-127.0.0.1}:3002:80"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,80 @@
+# Deployment — Linode (Tailscale + Cloudflare)
+
+部署到一台公網 Linode VM 的精簡指南。設計目標:**協議埠只走 Tailscale,公網不裸奔;前端走 Cloudflare 對外。**
+
+## 前置概念(兩個雷)
+
+1. **App 啟動時只做 seed,不建表** — 資料表靠 Alembic migration。`deploy.sh` 已把「先 migration 再啟動」包好,照用即可,別直接 `docker compose up`。
+2. **Docker 會繞過 ufw** — `ports:` 預設 publish 到 `0.0.0.0`(公網)。本專案用 `docker-compose.prod.yml` 把所有 port 改綁到 `BIND_IP`(= 本機 Tailscale IP),公網完全不 listen,所以**不需要**另外設 ufw / Linode Cloud Firewall 也能不裸奔(設了更保險)。
+
+## 1. 開 VM 與安裝
+
+- Ubuntu 24.04 LTS,**至少 2GB RAM**(前端 build 吃記憶體,1GB 易 OOM)
+- 安裝 Docker(`curl -fsSL https://get.docker.com | sh`,需 Compose v2.24+)與 Tailscale:
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up --ssh
+tailscale ip -4              # 記下本機 100.x.x.x
+```
+
+## 2. 取得程式碼與設定
+
+```bash
+git clone https://github.com/kencoolguy/GhostMeter.git ghostmeter && cd ghostmeter
+cp .env.example .env
+```
+
+編輯 `.env`,至少設定:
+
+```bash
+POSTGRES_PASSWORD=<強密碼，勿用預設>
+BIND_IP=<本機的 Tailscale IP，例如 100.x.x.x>
+DEBUG=false
+```
+
+> `DATABASE_URL` 不必手動設;compose 會用 `POSTGRES_PASSWORD` 自動組出來。
+> 前端走相對路徑 `/api/v1`,換網域不必重 build。
+
+## 3. 部署
+
+```bash
+./deploy.sh
+```
+
+`deploy.sh` 會依序:套用 `docker-compose.prod.yml` overlay → build image → 起 postgres 並等 healthy → 跑 `alembic upgrade head` → 啟動全部服務 → 顯示狀態。
+
+更新版本時(`git pull` 後)重跑 `./deploy.sh` 即可,有新 migration 也會一併套用。
+
+## 4. 驗證(在已連 Tailscale 的電腦)
+
+```bash
+http http://<BIND_IP>:8000/health                 # ✅ 走 tailnet 應該通
+http --timeout=5 http://<公網IP>:8000/health        # ✅ 應 timeout = 沒裸奔
+```
+
+協議埠測試:用 EMS / 工具連 `<BIND_IP>` 的 `502`(Modbus)、`4840`(OPC UA)、`161`(SNMP)。
+
+## 5. 前端對外(Cloudflare Tunnel)
+
+公網埠全鎖,所以用 **Cloudflare Tunnel**(純出站,不開任何入站埠)對外發布前端。在 Zero Trust → Networks → Tunnels 建 tunnel 取得 token,於 VM 加一個 service(可放 `docker-compose.override.yml` 或併入 prod overlay):
+
+```yaml
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel run
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}
+    restart: unless-stopped
+    depends_on:
+      - frontend
+```
+
+在 tunnel 的 Public Hostname 設定你的網域 → service `http://frontend:80`(同 compose network 用服務名),即取得公網 HTTPS 前端,且不暴露任何協議埠。
+
+## 相關檔案
+
+- `docker-compose.prod.yml` — 部署 overlay,把 port 綁到 `BIND_IP`、postgres 不對外
+- `deploy.sh` — build + migration + 啟動的一鍵腳本
+- `.env.example` — `BIND_IP` 欄位說明

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,23 @@
 # Development Log
 
+## 2026-06-10 — Deployment tooling (Linode / Tailscale / Cloudflare)
+
+### What was done
+- Added `docker-compose.prod.yml` overlay: binds backend/frontend ports to `BIND_IP` and removes PostgreSQL's public port, using `!override` to replace (not merge) the base 0.0.0.0 bindings
+- Added `deploy.sh`: applies the prod overlay, waits for postgres health, runs `alembic upgrade head`, then starts all services
+- Added `docs/deployment.md` (concise Linode guide) and a `BIND_IP` entry in `.env.example`
+
+### Key decisions
+- **Prod overlay via explicit `-f`, not `docker-compose.override.yml`**: the auto-loaded override file would also apply during local development, where tests connect to PostgreSQL on `localhost:5434`; removing the postgres port there would break the existing host-test workflow
+- **`!override` instead of default list merge**: Compose concatenates `ports` lists across files, which would keep the public 0.0.0.0 bindings alongside the Tailscale ones — defeating the purpose. `!override` (Compose v2.24+) replaces the list outright
+- **Bind to Tailscale IP rather than Linode Cloud Firewall**: achieves "not public" with a file in the repo instead of console state; Docker bypasses ufw, so a host-side bind address is the reliable lever. `BIND_IP` defaults to `127.0.0.1` so a missing value fails safe to local-only rather than exposing everything
+- **Cloudflare Tunnel for the public frontend**: outbound-only, so no inbound ports need opening and protocol ports stay private
+
+### Notes
+- App startup only seeds data; tables come from Alembic — `deploy.sh` runs migrations before bringing the app up so a fresh deploy doesn't fail on missing tables
+
+---
+
 ## 2026-06-03 — OPC UA Server Adapter (4th protocol)
 
 ### What was done

--- a/docs/development-phases.md
+++ b/docs/development-phases.md
@@ -166,6 +166,11 @@
 - [ ] Docker Hub image publish（deferred）
 - [ ] 在相關社群宣傳（deferred）
 
+### Milestone 7.4：正式部署工具 ✅ Complete (2026-06-10)
+- [x] `docker-compose.prod.yml`：port 綁定 `BIND_IP`、postgres 不對外（exposed host 安全部署）
+- [x] `deploy.sh`：套用 prod overlay + migration + 啟動 一鍵腳本
+- [x] `docs/deployment.md`：Linode（Tailscale + Cloudflare Tunnel）部署指南
+
 ---
 
 ## Phase 8：Post-MVP 功能擴充


### PR DESCRIPTION
## 摘要
新增公網主機(Linode)的安全部署工具。協議埠只走 Tailscale,公網不裸奔;前端走 Cloudflare Tunnel。

## 變更
- **`docker-compose.prod.yml`** — 部署 overlay,所有 port 綁到 `BIND_IP`(本機 Tailscale IP)、PostgreSQL 不對外 publish。用 `!override` 取代(而非疊加)base 的 0.0.0.0 綁定,確保公網不 listen。需 Compose v2.24+。
- **`deploy.sh`** — 一鍵:套 overlay → 起 postgres 等 healthy → `alembic upgrade head` → 啟動全部。
- **`docs/deployment.md`** — 精簡 Linode 部署指南(Tailscale + Cloudflare Tunnel)。
- **`.env.example`** — 新增 `BIND_IP`(未設時預設 127.0.0.1,fail-safe 綁本機)。

## 設計取捨
- **用 `-f` 明確指定 prod overlay,不用自動載入的 `docker-compose.override.yml`**:後者本機開發也會套用,會拿掉 postgres 的 `localhost:5434` port → 破壞既有 host 測試流程。
- **`!override` 而非預設 list merge**:compose 會把多檔的 `ports` 串接,merge 會保留公網 0.0.0.0 綁定 → 失去意義。
- **綁 Tailscale IP 而非 Linode Cloud Firewall**:Docker 繞過 ufw,host-side bind 才是可靠槓桿,且用 repo 內檔案管理而非主控台狀態。

## 注意
- App 啟動只 seed、不建表;`deploy.sh` 在啟動前先跑 migration,避免新部署因缺表失敗。
- 純新增檔案 + 文件,不動任何既有程式碼,對現有功能零影響。

🤖 Generated with [Claude Code](https://claude.com/claude-code)