### PR TITLE
feat: add update.sh one-shot update+redeploy helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Deployment tooling for exposed hosts: `docker-compose.prod.yml` overlay binds all published ports to `BIND_IP` (Tailscale IP) and stops publishing PostgreSQL, so nothing is exposed on the public network interface
 - `deploy.sh` one-shot deploy script (applies prod overlay, runs Alembic migrations before startup, brings services up)
+- `update.sh` one-shot update script (pulls latest `dev`, checks `.env` has `BIND_IP`, then runs `deploy.sh`)
 - `docs/deployment.md` — concise Linode deployment guide (Tailscale + Cloudflare Tunnel)
 - `.env.example`: new `BIND_IP` setting (defaults to 127.0.0.1 when unset, failing safe to local-only)
 - OPC UA comm-layer fault simulation: delay / timeout / exception / intermittent now

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ DEBUG=false
 
 `deploy.sh` 會依序:套用 `docker-compose.prod.yml` overlay → build image → 起 postgres 並等 healthy → 跑 `alembic upgrade head` → 啟動全部服務 → 顯示狀態。
 
-更新版本時(`git pull` 後)重跑 `./deploy.sh` 即可,有新 migration 也會一併套用。
+更新版本時直接跑 `./update.sh` —— 它會 `git pull` 最新 `dev`、檢查 `.env` 有 `BIND_IP`,再呼叫 `deploy.sh`(含新 migration)。
 
 ## 4. 驗證(在已連 Tailscale 的電腦)
 
@@ -77,4 +77,5 @@ services:
 
 - `docker-compose.prod.yml` — 部署 overlay,把 port 綁到 `BIND_IP`、postgres 不對外
 - `deploy.sh` — build + migration + 啟動的一鍵腳本
+- `update.sh` — `git pull` 最新 dev + 檢查 `.env` + 呼叫 `deploy.sh` 的更新腳本
 - `.env.example` — `BIND_IP` 欄位說明

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Update the deploy host to the latest origin/dev and redeploy.
+#
+# Run from the repo root on the deploy host:
+#   ./update.sh
+#
+# It pulls the latest dev, sanity-checks .env, then hands off to deploy.sh
+# (which applies the prod overlay, runs migrations, and brings services up).
+# .env is git-ignored, so your POSTGRES_PASSWORD / BIND_IP are never touched.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "==> Fetching latest origin/dev"
+git fetch origin
+git checkout dev
+git pull --ff-only origin dev
+
+if [ ! -f .env ]; then
+  echo "ERROR: .env not found. Run: cp .env.example .env  then set POSTGRES_PASSWORD + BIND_IP." >&2
+  exit 1
+fi
+
+if ! grep -q '^BIND_IP=' .env; then
+  echo "ERROR: BIND_IP is not set in .env." >&2
+  echo "       Add this host's Tailscale IP, e.g.:  echo 'BIND_IP=100.x.x.x' >> .env" >&2
+  exit 1
+fi
+
+echo "==> Redeploying"
+exec ./deploy.sh


### PR DESCRIPTION
## 摘要
新增 `update.sh`:部署主機上一鍵更新到最新 `dev` 並重新部署。

## 內容
- `git fetch` + `checkout dev` + `pull --ff-only` 取最新
- 檢查 `.env` 存在且含 `BIND_IP`,缺少就 fail-fast 並提示(**不寫死 IP**,因為腳本在 repo 內)
- `exec ./deploy.sh` 接手(prod overlay + migration + 啟動)
- 文件:CHANGELOG、`docs/deployment.md` 更新

## 用法
```bash
cd ~/ghostmeter && ./update.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)