### PR TITLE
chore: cut release 0.4.0 (Milestone 8.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-11
+
 ### Added
 - Comm-layer fault simulation for BACnet, SNMP, and MQTT — all five protocols now support `delay` / `timeout` / `intermittent` faults through `PUT /devices/{id}/fault` (pull-based, same model as Modbus). BACnet: faulted devices also stop answering Who-Is (fully dark, like a real dead device); `exception` maps to BACnet Error `device/operationalProblem`. SNMP: `exception` maps to `genErr`; delayed responses are deferred without blocking the event loop. MQTT: `timeout` stops publishing, `intermittent` randomly skips publishes, `delay` publishes late; `exception` is rejected with 422 (publish-only protocols have no request/response channel to return an error on).
 - BACnet/IP protocol adapter (5th protocol): Who-Is/I-Am discovery, ReadProperty / ReadPropertyMultiple. One UDP port (47808) with a virtual-network router topology — each device is an independent BACnet device instance (`100000 + slave_id`); registers map to read-only analog-input objects with engineering units. Per-device read statistics included.
@@ -29,15 +31,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - WebSocket monitor_update payload 新增 `mqtt_broker_connected` 欄位
 - DeviceMonitorData 新增 `mqtt_stats`、`template_name` 欄位
 
-### Fixed
-- **Modbus fault params were unsanitized**: `delay_ms` was applied raw with no cap — `delay_ms=999999` blocked the response (and the event loop, since `trace_pdu` is a sync callback) for ~17 minutes, while the other four protocols cap at 10 s; and a malformed `failure_rate` (e.g. a string) raised `TypeError` inside `trace_pdu`, killing the request. Modbus now consumes the shared `get_delay_seconds` (10 s cap, NaN/inf guard) and `get_failure_rate` (0–1 clamp) helpers — fault-param semantics are now identical across all five protocols.
-- **BACnet replies deadlocked on wildcard bind (`0.0.0.0/0`, the production default) on hosts that cannot bind 255.255.255.255** (e.g. macOS): bacpypes3 creates a second endpoint task for the subnet broadcast address, and `IPv4DatagramServer.indication()` awaits ALL transport tasks before sending any reply — with `/0` the broadcast is 255.255.255.255, whose bind fails on macOS and retries forever, so inbound requests arrived but every response hung. The adapter now drops the doomed broadcast endpoint task when the configured prefix has no usable subnet broadcast (prefixlen 0) and logs a warning; unicast reads work, broadcast Who-Is discovery requires a concrete interface CIDR.
-- **BACnet WriteProperty was accepted (spec violation)**: bacpypes3's local analog-input objects accept writes to presentValue (runtime-verified: wrote 999.0, re-read 999.0). Simulated devices are read-only — values come from the simulation engine — so `WriteProperty` now returns a proper BACnet Error (`property` / `writeAccessDenied`) and the simulated value is untouched.
-- **SNMP devices stopped serving values after a restart**: the startup auto-resume path (`app/main.py`) re-registered OIDs but, unlike `device_service.start_device`, never called `set_register_names`, so resumed SNMP devices resolved OIDs by raw-OID key instead of register name and returned `noSuchObject`. Resume now rebuilds the SNMP OID→name map, so SNMP survives restarts / boot auto-start.
-- **SNMP agent never served register values**: the adapter registered OIDs and could `resolve_oid()`, but `start()` wired pysnmp's command responders to the default (empty) MIB context, so every real GET/GETNEXT returned `noSuchObject` (unit tests only called `resolve_oid` directly, so they passed). Added a `_DynamicMibController` (`AbstractMibInstrumController`) bridging GET/GETNEXT to `resolve_oid`/`get_next_oid` and registered it on the null context. Added an integration test that performs a real SNMP GET/GETNEXT through the agent.
-- **UPS "Normal Operation" profile crashed the simulation engine**: `output_power`'s computed expression used bare variable names (`output_voltage * output_current`) instead of the required `{braces}`, so the parser saw an `ast.Name` and raised, stopping the device after 5 consecutive errors. Fixed the seed expression to `{output_voltage} * {output_current}`; added a seed-validation assertion that all computed expressions use braced variables.
-- **CI 6h timeout on OPC UA server tests** (root cause of issue #37, previously mis-attributed to asyncpg): coverage's default C trace function fires per-line on every module, and asyncua rebuilds its ~100k-line standard address space on each `Server.init()`. Under `pytest --cov` each OPC UA server test took ~11 min, blowing the 6h job limit. Fixed by `[tool.coverage.run] core = "sysmon"` (PEP 669 `sys.monitoring`), which skips instrumentation of non-`source` files — `Server.init()` drops from >240s to ~0.4s under coverage.
-- Quieted the `asyncua` logger to WARNING in `app/main.py` (secondary cleanup): each `Server.init()` emits ~1100 INFO lines loading the standard address space, spamming startup logs. Not the CI fix.
+- Auto-resume: backend now automatically resumes running devices on startup (registers in protocol adapters + restarts simulation engine)
+- Device Detail: register table now shows live values via WebSocket (replaces hard-coded null)
+- Device Detail: "Open in Monitor" button navigates to Monitor page with device auto-selected
+- Device Detail: Live/Disconnected connection status badge on Register Map card
+- Monitor: supports `?device=<id>` query param for auto-selecting a device on page load
+
+- Scenario mode: reusable anomaly injection timelines bound to device templates
+- Scenario CRUD API (`/api/v1/scenarios`) with list, get, create, update, delete, export, import
+- Scenario execution API: start/stop/status per device (`/api/v1/devices/{id}/scenario/...`)
+- ScenarioRunner: async executor that triggers anomaly injections on a timeline
+- Built-in scenario seeds: Power Outage Recovery, Voltage Instability, Inverter Fault Sequence
+- `scenarios` and `scenario_steps` DB tables with Alembic migration
+- Frontend Scenarios page: list view with template filter, create/edit/delete/clone/export/import
+- Frontend timeline editor: drag-and-drop anomaly blocks on a register×time grid
+- Frontend scenario execution card on Device Detail page with start/stop and real-time progress
+- 19 integration tests for scenario CRUD, seed loading, built-in protection, and export/import
 
 ### Changed
 - `/` route 改導向 `/monitor`（原 `/templates`）
@@ -59,23 +68,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - 移除死代碼：SimulationEngine `_device_tasks` 相容 property、從未被讀取的 `last_restart`；BACnet 兩個 byte-identical read handler 合併；scenario step 欄位清單三份手抄合併為 helper
   - 測試:`tests/netutil.py` 共用 free-port helpers（原本 5 個檔案各自定義）、`clean_faults` 改為 conftest 全域 autouse fixture
 
-### Removed
-- `pages/Monitor/DeviceDetailPanel.tsx`、`RegisterChart.tsx`、`StatsPanel.tsx`、`EventLog.tsx`
-- monitorStore 的 `selectedDeviceId` / `selectDevice`
-
-### Previously Added
-- Auto-resume: backend now automatically resumes running devices on startup (registers in protocol adapters + restarts simulation engine)
-- Device Detail: register table now shows live values via WebSocket (replaces hard-coded null)
-- Device Detail: "Open in Monitor" button navigates to Monitor page with device auto-selected
-- Device Detail: Live/Disconnected connection status badge on Register Map card
-- Monitor: supports `?device=<id>` query param for auto-selecting a device on page load
-
-### Changed
 - Monitor DeviceCard preview: defaults to total_power + total_energy instead of voltage_l1/l2
 - Monitor chart selector: changed to multi-select, defaults to total_power + total_energy
 - Batch device name prefix: removed extra space between prefix and slave ID (e.g. "Meter1" instead of "Meter 1")
 
+- MQTT publish config card: edit/publish mode separation — fields locked during publishing, "Stop publishing to edit settings" hint
+- MQTT publishing status indicator (green `MQTT` tag) in device list and device detail pages
+- `mqtt_publishing` boolean field added to device list API response
+- Unified button styles: Start Publishing uses green primary, Stop Publishing uses danger
+
 ### Fixed
+- **Modbus fault params were unsanitized**: `delay_ms` was applied raw with no cap — `delay_ms=999999` blocked the response (and the event loop, since `trace_pdu` is a sync callback) for ~17 minutes, while the other four protocols cap at 10 s; and a malformed `failure_rate` (e.g. a string) raised `TypeError` inside `trace_pdu`, killing the request. Modbus now consumes the shared `get_delay_seconds` (10 s cap, NaN/inf guard) and `get_failure_rate` (0–1 clamp) helpers — fault-param semantics are now identical across all five protocols.
+- **BACnet replies deadlocked on wildcard bind (`0.0.0.0/0`, the production default) on hosts that cannot bind 255.255.255.255** (e.g. macOS): bacpypes3 creates a second endpoint task for the subnet broadcast address, and `IPv4DatagramServer.indication()` awaits ALL transport tasks before sending any reply — with `/0` the broadcast is 255.255.255.255, whose bind fails on macOS and retries forever, so inbound requests arrived but every response hung. The adapter now drops the doomed broadcast endpoint task when the configured prefix has no usable subnet broadcast (prefixlen 0) and logs a warning; unicast reads work, broadcast Who-Is discovery requires a concrete interface CIDR.
+- **BACnet WriteProperty was accepted (spec violation)**: bacpypes3's local analog-input objects accept writes to presentValue (runtime-verified: wrote 999.0, re-read 999.0). Simulated devices are read-only — values come from the simulation engine — so `WriteProperty` now returns a proper BACnet Error (`property` / `writeAccessDenied`) and the simulated value is untouched.
+- **SNMP devices stopped serving values after a restart**: the startup auto-resume path (`app/main.py`) re-registered OIDs but, unlike `device_service.start_device`, never called `set_register_names`, so resumed SNMP devices resolved OIDs by raw-OID key instead of register name and returned `noSuchObject`. Resume now rebuilds the SNMP OID→name map, so SNMP survives restarts / boot auto-start.
+- **SNMP agent never served register values**: the adapter registered OIDs and could `resolve_oid()`, but `start()` wired pysnmp's command responders to the default (empty) MIB context, so every real GET/GETNEXT returned `noSuchObject` (unit tests only called `resolve_oid` directly, so they passed). Added a `_DynamicMibController` (`AbstractMibInstrumController`) bridging GET/GETNEXT to `resolve_oid`/`get_next_oid` and registered it on the null context. Added an integration test that performs a real SNMP GET/GETNEXT through the agent.
+- **UPS "Normal Operation" profile crashed the simulation engine**: `output_power`'s computed expression used bare variable names (`output_voltage * output_current`) instead of the required `{braces}`, so the parser saw an `ast.Name` and raised, stopping the device after 5 consecutive errors. Fixed the seed expression to `{output_voltage} * {output_current}`; added a seed-validation assertion that all computed expressions use braced variables.
+- **CI 6h timeout on OPC UA server tests** (root cause of issue #37, previously mis-attributed to asyncpg): coverage's default C trace function fires per-line on every module, and asyncua rebuilds its ~100k-line standard address space on each `Server.init()`. Under `pytest --cov` each OPC UA server test took ~11 min, blowing the 6h job limit. Fixed by `[tool.coverage.run] core = "sysmon"` (PEP 669 `sys.monitoring`), which skips instrumentation of non-`source` files — `Server.init()` drops from >240s to ~0.4s under coverage.
+- Quieted the `asyncua` logger to WARNING in `app/main.py` (secondary cleanup): each `Server.init()` emits ~1100 INFO lines loading the standard address space, spamming startup logs. Not the CI fix.
+
 - Pinned `pymodbus>=3.12,<3.13`: the unbounded `>=3.12` constraint resolved to 3.13.0 on fresh installs (CI / container rebuild), whose `ModbusServerContext(devices={})` change broke the Modbus TCP server and its tests. Capped to the 3.12.x line until the adapter is adapted to 3.13.
 - Simulation engine crash recovery: tasks that crash (e.g. network disconnection) now auto-restart with exponential backoff (max 5 attempts), and DB status correctly updates to "error" when recovery fails
 - Inner adapter errors (e.g. pymodbus write failures) now count toward consecutive error threshold, preventing silent simulation death while device status stays "running"
@@ -83,7 +94,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Devices with status=running showed no register values after backend restart (simulation engine was not resumed)
 - Frontend `package.json` scripts no longer hard-code VirtualBox shared-folder workaround paths (`/home/ken/.ghostmeter-frontend-modules/...`); `npm run dev` / `npm run build` / `npm run lint` now use standard tooling and work on any machine after `npm install`
 
+- Resolved 91 ruff lint errors accumulated in `backend/` since CI was removed on 2026-03-20 (31 unsorted imports, 12 unused imports, 44 line-too-long, 2 unused variables, 1 module-level import not at top, 1 trailing whitespace). CI is now green.
+- `backend/pyproject.toml`: added `alembic/versions/*` to ruff `per-file-ignores` for `E501` — auto-generated migration files get long type declarations that reappear on each regen and shouldn't be hand-wrapped.
+- `backend/app/services/scenario_runner.py`: documented why the `_anomaly_injector` import is late (circular-import avoidance) and added `# noqa: E402` with the explanation.
+
 ### Removed
+- `pages/Monitor/DeviceDetailPanel.tsx`、`RegisterChart.tsx`、`StatsPanel.tsx`、`EventLog.tsx`
+- monitorStore 的 `selectedDeviceId` / `selectDevice`
+
 - `frontend/tsconfig.local.json`, `tsconfig.local.app.json`, `tsconfig.local.node.json` (VirtualBox shared-folder node_modules workaround — no longer needed)
 - `frontend/.npmrc` comment file (workaround documentation)
 - `frontend/package.json` `build:local` script (workaround for vboxsf symlink issue)
@@ -93,11 +111,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Backend job: Python 3.12 + PostgreSQL 16 service + ruff lint + alembic migrate + pytest with coverage
 - Frontend job: Node 22 (aligned with Dockerfile) + `tsc -b` type check + `npm run build`
 
-### Fixed (lint debt)
-- Resolved 91 ruff lint errors accumulated in `backend/` since CI was removed on 2026-03-20 (31 unsorted imports, 12 unused imports, 44 line-too-long, 2 unused variables, 1 module-level import not at top, 1 trailing whitespace). CI is now green.
-- `backend/pyproject.toml`: added `alembic/versions/*` to ruff `per-file-ignores` for `E501` — auto-generated migration files get long type declarations that reappear on each regen and shouldn't be hand-wrapped.
-- `backend/app/services/scenario_runner.py`: documented why the `_anomaly_injector` import is late (circular-import avoidance) and added `# noqa: E402` with the explanation.
-
 ### Documentation
 - `docs/api-reference.md`: documented 18 previously-undocumented endpoints surfaced during consolidation drift check
   - Anomaly injection: `POST/GET/DELETE /devices/{id}/anomaly`, `DELETE /devices/{id}/anomaly/{register_name}`, `GET/PUT/DELETE /devices/{id}/anomaly/schedules`
@@ -106,24 +119,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Simulation profiles: `GET /simulation-profiles/template/{template_id}` (blank template download), `POST /simulation-profiles/import` (with `template_id` query param), `GET /simulation-profiles/{profile_id}/export`
 - `docs/api-reference.md` `RegisterValue` schema: added `oid` field (used for SNMP templates) and replaced the stale "Phase 3: always null" note on `value` with an accurate description pointing to `/ws/monitor` for live values
 - `docs/development-phases.md`: added Milestone 8.6 (Polish & UX Fixes) and Milestone 8.7 (Consolidation, in progress) to reflect work completed since Scenario Mode shipped
-
-### Previously Added
-- Scenario mode: reusable anomaly injection timelines bound to device templates
-- Scenario CRUD API (`/api/v1/scenarios`) with list, get, create, update, delete, export, import
-- Scenario execution API: start/stop/status per device (`/api/v1/devices/{id}/scenario/...`)
-- ScenarioRunner: async executor that triggers anomaly injections on a timeline
-- Built-in scenario seeds: Power Outage Recovery, Voltage Instability, Inverter Fault Sequence
-- `scenarios` and `scenario_steps` DB tables with Alembic migration
-- Frontend Scenarios page: list view with template filter, create/edit/delete/clone/export/import
-- Frontend timeline editor: drag-and-drop anomaly blocks on a register×time grid
-- Frontend scenario execution card on Device Detail page with start/stop and real-time progress
-- 19 integration tests for scenario CRUD, seed loading, built-in protection, and export/import
-
-### Changed
-- MQTT publish config card: edit/publish mode separation — fields locked during publishing, "Stop publishing to edit settings" hint
-- MQTT publishing status indicator (green `MQTT` tag) in device list and device detail pages
-- `mqtt_publishing` boolean field added to device list API response
-- Unified button styles: Start Publishing uses green primary, Stop Publishing uses danger
 
 ## [0.3.0] - 2026-03-27
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Multi-protocol device simulator for energy management systems.
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue)]()
+[![Version](https://img.shields.io/badge/version-0.4.0-blue)]()
 [![Python](https://img.shields.io/badge/python-3.12+-blue)]()
 [![License](https://img.shields.io/badge/license-MIT-green)]()
 
@@ -18,7 +18,8 @@
 - **Profile management**: Export, import, and blank template download for easy sharing
 - **5 data generation modes**: static, random, daily curve, computed, accumulator
 - **Anomaly injection**: spike, drift, flatline, out-of-range, data loss (real-time + scheduled)
-- **Fault simulation**: delay, timeout, exception, intermittent communication
+- **Scenario mode**: reusable anomaly timelines per template with a drag-and-drop editor, built-in scenario presets, and per-device execution with live progress
+- **Fault simulation**: delay, timeout, exception, intermittent communication — supported across all five protocols
 - **Real-time monitoring**: WebSocket dashboard with charts and event log
 - **Batch operations**: Start, stop, and delete multiple devices at once
 - **Config export/import**: Full system snapshot including MQTT settings and simulation profiles

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
 
     # App
     APP_NAME: str = "GhostMeter"
-    APP_VERSION: str = "0.1.0"
+    APP_VERSION: str = "0.4.0"
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,25 @@
 # Development Log
 
+## 2026-06-11 — Cut release 0.4.0 準備（Milestone 8.7）
+
+### 做了什麼
+
+- **版本號對齊 0.4.0**：原本三處版本各自為政——README badge 0.3.0、backend
+  `APP_VERSION` 0.1.0（從未 bump 過）、frontend `package.json` 0.1.0。
+  選 0.4.0 是因為自 0.3.0 後是大量向後相容的功能新增（SNMP/OPC UA/BACnet 三個
+  協議、5 協議 fault parity、Scenario mode、Monitor 改版），尚未到 1.0。
+- **CHANGELOG cut**：`[Unreleased]` 整段移入 `[0.4.0] - 2026-06-11`，並把歷次
+  push 累積的重複章節標題（兩個 Previously Added、多個 Changed/Fixed）依
+  keep-a-changelog 慣例機械式合併（條目逐字保留，僅重新分組），留下空的
+  `[Unreleased]`。
+- README features 補上 Scenario mode（0.4.0 主打功能漏列）。
+- 後端 full suite 健康檢查：**380 passed、0 skipped**。
+
+### 待人工執行
+
+兩個 PR（#47 /simplify 清理、release prep）審查合併進 dev 後，開 dev→main PR
+並在 merge 後打 `v0.4.0` tag。
+
 ## 2026-06-11 — Pre-release /simplify 清理（Milestone 8.7）
 
 ### 做了什麼

--- a/docs/development-phases.md
+++ b/docs/development-phases.md
@@ -286,9 +286,9 @@
 - [x] API reference drift fix: document 18 previously undocumented endpoints (anomaly, simulation config, fault, simulation-profile import/export/blank)
 - [x] `RegisterValue` schema: document `oid` field and update stale `value` description
 - [x] Pre-release /simplify cleanup pass over `main...dev`: 14 behavior-preserving fixes applied (adapter fault-type capability, shared device-runtime registration, SNMP one-phase name map, frontend anomaly constants, monitor history/render perf, CSS-variable theming, test helper consolidation) — see dev log 2026-06-11; 5 findings deferred (OPC UA blocking delay, scenario param validation semantics, monitor DB cache, fault-action resolver, adapter_status generalization)
-- [ ] Push feature branch and verify CI pipeline runs green
-- [ ] Backend test health check (`pytest` full run, confirm no skipped/flaky tests)
-- [ ] Cut release (resolve README 0.3.0 vs. current unreleased feature gap)
+- [x] Backend test health check: full `pytest` run **380 passed, 0 skipped** (2026-06-11, host venv vs ghostmeter_test DB)
+- [x] Cut release prep: version aligned to **0.4.0** everywhere (README badge was 0.3.0; backend `APP_VERSION` and frontend `package.json` were still 0.1.0); CHANGELOG `[Unreleased]` consolidated into a `[0.4.0] - 2026-06-11` section (duplicate subsection headers from successive pushes merged); README features list gained Scenario mode
+- [ ] Verify CI pipeline green on release PRs, merge to dev, then dev→main PR + `v0.4.0` tag (human review)
 - [ ] Address issues surfaced during audit: #21 (Cloudflare Pages build config), #22 (npm audit vulnerabilities), #23 (frontend bundle >500KB)
 
 ---

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "antd": "^6.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

> **Stacked on #47** — base 設為 simplify 分支讓 diff 只顯示 release 變更；#47 merge 進 dev 後此 PR 會自動 retarget。

- **版本對齊 0.4.0**：README badge（原 0.3.0）、backend `APP_VERSION`（原 0.1.0，從未 bump）、frontend `package.json` + lock（原 0.1.0）
- **CHANGELOG cut**：`[Unreleased]` → `[0.4.0] - 2026-06-11`；歷次 push 累積的重複章節（Previously Added ×2、Changed/Fixed/Removed ×2）機械式合併（條目逐字保留，僅重新分組），留下空的 `[Unreleased]`
- README features 補列 Scenario mode；fault simulation 註明涵蓋全部 5 協議
- phases / dev log 同步更新（含 full pytest 健康檢查紀錄：**380 passed、0 skipped**）

## 0.4.0 內容概要（自 0.3.0）
SNMP / OPC UA / BACnet 三個新協議 adapter、5 協議 comm-layer fault parity、Scenario mode（timeline 編輯器 + 內建場景）、Monitor 首頁改版、MQTT publish UX、CI 恢復 + lint debt 清理、Linode 部署工具鏈、/simplify 清理（#47）。

## Merge 後的人工步驟
1. Review + merge #47 → dev,此 PR retarget 到 dev 後再 review + merge
2. 開 dev → main PR
3. main merge 後打 tag:`git tag v0.4.0 && git push origin v0.4.0`

## Test plan
- 後端 full suite 380 passed(同 #47 分支,本分支僅版本號/文件變更)
- `APP_VERSION` 變更僅影響 FastAPI title/version 顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)