### PR TITLE
fix: negative max_drift sign-flip in builtin scenario + unified step param validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Builtin "Fault Disconnect" scenario flipped dc_voltage upward mid-step**: the seed used `max_drift: -50`, but `max_drift` is a magnitude — the injector clamps with `abs(drift) > abs(max_drift)` and takes the direction from `drift_per_second`'s sign, so once the cap was reached (10 s into the 28 s step) the clamp produced `-max_drift = +50` and the intended -50 V sag jumped to +50 V above baseline for the remaining 18 s. Seed fixed to `max_drift: 50`; Alembic data migration `a7c3e91f4b20` repairs already-seeded builtin rows (user scenarios untouched).
+
+### Changed
+- **Scenario steps now validate anomaly params** like real-time injection and schedules already did (shared `AnomalyParamsBase`): required params per type, spike `multiplier > 0` / `probability` in [0,1], drift `max_drift > 0`. Previously a step with missing or invalid params was accepted and only failed at runtime mid-scenario. Affects scenario create / update / import (422 on bad params).
+
 ## [0.4.0] - 2026-06-11
 
 ### Added

--- a/backend/alembic/versions/a7c3e91f4b20_fix_negative_max_drift_in_builtin_.py
+++ b/backend/alembic/versions/a7c3e91f4b20_fix_negative_max_drift_in_builtin_.py
@@ -1,0 +1,50 @@
+"""Fix negative max_drift in builtin scenario steps.
+
+max_drift is a magnitude — the drift direction comes from drift_per_second's
+sign (anomaly_injector clamps with `abs(drift) > abs(max_drift)` and takes the
+sign from drift_per_second). A negative max_drift made the clamp flip the
+drift's sign once the cap was reached: the builtin "Fault Disconnect" scenario
+(drift_per_second=-5, max_drift=-50) sagged dc_voltage for 10 s and then
+jumped it to +50 ABOVE baseline for the rest of the step.
+
+The seed JSON is fixed in the same change; this migration repairs rows that
+were already seeded (the seed loader skips existing builtin scenarios).
+Only builtin scenarios are touched — user-created steps with negative
+max_drift are now rejected at the API, but existing user data is left alone.
+
+Revision ID: a7c3e91f4b20
+Revises: b241433f7174
+Create Date: 2026-06-11
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a7c3e91f4b20"
+down_revision: str | None = "b241433f7174"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE scenario_steps AS ss
+        SET anomaly_params = jsonb_set(
+                ss.anomaly_params,
+                '{max_drift}',
+                to_jsonb(abs((ss.anomaly_params ->> 'max_drift')::numeric))
+            )
+        FROM scenarios AS s
+        WHERE s.id = ss.scenario_id
+          AND s.is_builtin IS TRUE
+          AND ss.anomaly_type = 'drift'
+          AND (ss.anomaly_params ->> 'max_drift')::numeric < 0
+        """
+    )
+
+
+def downgrade() -> None:
+    # Irreversible data repair: the original (buggy) negative values are not
+    # preserved. Downgrade is a no-op.
+    pass

--- a/backend/app/schemas/anomaly.py
+++ b/backend/app/schemas/anomaly.py
@@ -17,10 +17,15 @@ _REQUIRED_PARAMS: dict[str, list[str]] = {
 }
 
 
-class AnomalyInjectRequest(BaseModel):
-    """Schema for real-time anomaly injection (in-memory)."""
+class AnomalyParamsBase(BaseModel):
+    """Shared anomaly_type + anomaly_params validation.
 
-    register_name: str
+    Inherited by real-time injection, schedules, and scenario steps so all
+    three entry points enforce identical param rules. Note `max_drift` is a
+    magnitude — the drift direction comes from `drift_per_second`'s sign
+    (see anomaly_injector._apply_anomaly), hence the > 0 rule.
+    """
+
     anomaly_type: str
     anomaly_params: dict[str, Any] = {}
 
@@ -32,7 +37,7 @@ class AnomalyInjectRequest(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def validate_params(self) -> "AnomalyInjectRequest":
+    def validate_params(self) -> "AnomalyParamsBase":
         required = _REQUIRED_PARAMS.get(self.anomaly_type, [])
         for param in required:
             if param not in self.anomaly_params:
@@ -51,6 +56,12 @@ class AnomalyInjectRequest(BaseModel):
         return self
 
 
+class AnomalyInjectRequest(AnomalyParamsBase):
+    """Schema for real-time anomaly injection (in-memory)."""
+
+    register_name: str
+
+
 class AnomalyActiveResponse(BaseModel):
     """Response for an active (real-time) anomaly."""
 
@@ -59,22 +70,13 @@ class AnomalyActiveResponse(BaseModel):
     anomaly_params: dict[str, Any]
 
 
-class AnomalyScheduleCreate(BaseModel):
+class AnomalyScheduleCreate(AnomalyParamsBase):
     """Schema for a single anomaly schedule entry."""
 
     register_name: str
-    anomaly_type: str
-    anomaly_params: dict[str, Any] = {}
     trigger_after_seconds: int
     duration_seconds: int
     is_enabled: bool = True
-
-    @field_validator("anomaly_type")
-    @classmethod
-    def validate_anomaly_type(cls, v: str) -> str:
-        if v not in VALID_ANOMALY_TYPES:
-            raise ValueError(f"anomaly_type must be one of {VALID_ANOMALY_TYPES}")
-        return v
 
     @field_validator("trigger_after_seconds")
     @classmethod
@@ -89,25 +91,6 @@ class AnomalyScheduleCreate(BaseModel):
         if v <= 0:
             raise ValueError("duration_seconds must be > 0")
         return v
-
-    @model_validator(mode="after")
-    def validate_params(self) -> "AnomalyScheduleCreate":
-        required = _REQUIRED_PARAMS.get(self.anomaly_type, [])
-        for param in required:
-            if param not in self.anomaly_params:
-                raise ValueError(
-                    f"anomaly_type '{self.anomaly_type}' requires param '{param}'"
-                )
-        if self.anomaly_type == "spike":
-            if self.anomaly_params["multiplier"] <= 0:
-                raise ValueError("multiplier must be > 0")
-            prob = self.anomaly_params["probability"]
-            if not 0 <= prob <= 1:
-                raise ValueError("probability must be between 0 and 1")
-        elif self.anomaly_type == "drift":
-            if self.anomaly_params["max_drift"] <= 0:
-                raise ValueError("max_drift must be > 0")
-        return self
 
 
 class AnomalyScheduleBatchSet(BaseModel):

--- a/backend/app/schemas/scenario.py
+++ b/backend/app/schemas/scenario.py
@@ -6,25 +6,22 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from app.schemas.anomaly import VALID_ANOMALY_TYPES
+from app.schemas.anomaly import AnomalyParamsBase
 
 
-class ScenarioStepCreate(BaseModel):
-    """Schema for creating a single scenario step."""
+class ScenarioStepCreate(AnomalyParamsBase):
+    """Schema for creating a single scenario step.
+
+    Inherits anomaly_type/anomaly_params validation from AnomalyParamsBase so
+    scenario steps enforce the same param rules as real-time injection and
+    schedules (a step with bad params would otherwise only fail at runtime,
+    mid-scenario).
+    """
 
     register_name: str
-    anomaly_type: str
-    anomaly_params: dict[str, Any] = {}
     trigger_at_seconds: int
     duration_seconds: int
     sort_order: int = 0
-
-    @field_validator("anomaly_type")
-    @classmethod
-    def validate_anomaly_type(cls, v: str) -> str:
-        if v not in VALID_ANOMALY_TYPES:
-            raise ValueError(f"anomaly_type must be one of {VALID_ANOMALY_TYPES}")
-        return v
 
     @field_validator("trigger_at_seconds")
     @classmethod

--- a/backend/app/seed/scenarios/solar_inverter_fault.json
+++ b/backend/app/seed/scenarios/solar_inverter_fault.json
@@ -4,7 +4,7 @@
   "description": "Simulates inverter fault: AC power drops, DC voltage drifts, efficiency zeroes",
   "steps": [
     {"register_name": "ac_power", "anomaly_type": "flatline", "anomaly_params": {"value": 0}, "trigger_at_seconds": 0, "duration_seconds": 30, "sort_order": 0},
-    {"register_name": "dc_voltage", "anomaly_type": "drift", "anomaly_params": {"drift_per_second": -5, "max_drift": -50}, "trigger_at_seconds": 2, "duration_seconds": 28, "sort_order": 1},
+    {"register_name": "dc_voltage", "anomaly_type": "drift", "anomaly_params": {"drift_per_second": -5, "max_drift": 50}, "trigger_at_seconds": 2, "duration_seconds": 28, "sort_order": 1},
     {"register_name": "efficiency", "anomaly_type": "out_of_range", "anomaly_params": {"value": 0}, "trigger_at_seconds": 5, "duration_seconds": 25, "sort_order": 2}
   ]
 }

--- a/backend/tests/test_anomaly_injector.py
+++ b/backend/tests/test_anomaly_injector.py
@@ -97,6 +97,24 @@ class TestInjectAndApply:
         result = injector.apply(device_id, "voltage", 230.0, 20.0)
         assert result == 235.0
 
+    def test_negative_drift_caps_at_negative_magnitude(
+        self, injector: AnomalyInjector, device_id: uuid.UUID
+    ) -> None:
+        """max_drift is a magnitude: with a negative drift_per_second the
+        drift saturates at -max_drift and must never flip sign.
+
+        Regression context: the builtin Fault Disconnect seed shipped
+        max_drift=-50, which made the clamp (`-max_drift`) flip a -50 sag
+        into +50 above baseline once the cap was reached."""
+        injector.inject(
+            device_id, "voltage", "drift",
+            {"drift_per_second": -5.0, "max_drift": 50.0},
+        )
+        assert injector.apply(device_id, "voltage", 230.0, 0.0) == 230.0
+        assert injector.apply(device_id, "voltage", 230.0, 5.0) == 205.0
+        # Far past the cap (raw drift would be -150): stays at -50, no flip.
+        assert injector.apply(device_id, "voltage", 230.0, 30.0) == 180.0
+
 
 class TestRemoveAndClear:
     def test_remove_specific_register(

--- a/backend/tests/test_scenarios.py
+++ b/backend/tests/test_scenarios.py
@@ -155,7 +155,7 @@ class TestScenarioCRUD:
                 {
                     "register_name": "nonexistent_register",
                     "anomaly_type": "spike",
-                    "anomaly_params": {},
+                    "anomaly_params": {"multiplier": 2.0, "probability": 0.5},
                     "trigger_at_seconds": 0,
                     "duration_seconds": 10,
                 },
@@ -173,14 +173,14 @@ class TestScenarioCRUD:
                 {
                     "register_name": "voltage",
                     "anomaly_type": "spike",
-                    "anomaly_params": {},
+                    "anomaly_params": {"multiplier": 2.0, "probability": 0.5},
                     "trigger_at_seconds": 0,
                     "duration_seconds": 20,
                 },
                 {
                     "register_name": "voltage",
                     "anomaly_type": "drift",
-                    "anomaly_params": {},
+                    "anomaly_params": {"drift_per_second": 1.0, "max_drift": 10.0},
                     "trigger_at_seconds": 10,
                     "duration_seconds": 15,
                 },
@@ -188,6 +188,47 @@ class TestScenarioCRUD:
         }
         resp = await client.post("/api/v1/scenarios", json=payload)
         assert resp.status_code == 422
+
+    async def test_step_anomaly_params_validated(self, client: AsyncClient) -> None:
+        """Scenario steps enforce the same anomaly-param rules as real-time
+        injection and schedules (shared AnomalyParamsBase)."""
+        template = await create_template(client)
+
+        def payload_with_step(step: dict) -> dict:
+            return {
+                "template_id": template["id"],
+                "name": "Param Validation Scenario",
+                "steps": [{
+                    "register_name": "voltage",
+                    "trigger_at_seconds": 0,
+                    "duration_seconds": 10,
+                    **step,
+                }],
+            }
+
+        # Negative max_drift rejected: max_drift is a magnitude (direction
+        # comes from drift_per_second's sign); a negative value made the
+        # injector clamp flip the drift sign at the cap.
+        resp = await client.post("/api/v1/scenarios", json=payload_with_step({
+            "anomaly_type": "drift",
+            "anomaly_params": {"drift_per_second": -5, "max_drift": -50},
+        }))
+        assert resp.status_code == 422
+
+        # Spike without its required params rejected
+        resp = await client.post("/api/v1/scenarios", json=payload_with_step({
+            "anomaly_type": "spike",
+            "anomaly_params": {},
+        }))
+        assert resp.status_code == 422
+
+        # Downward sag expressed correctly (negative rate, positive
+        # magnitude) is valid
+        resp = await client.post("/api/v1/scenarios", json=payload_with_step({
+            "anomaly_type": "drift",
+            "anomaly_params": {"drift_per_second": -5, "max_drift": 50},
+        }))
+        assert resp.status_code == 201
 
     async def test_export_scenario(self, client: AsyncClient) -> None:
         template = await create_template(client)

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -93,3 +93,23 @@ class TestSeedLoader:
         clone = response.json()["data"]
         assert clone["name"] == "My Custom Meter"
         assert clone["is_builtin"] is False
+
+
+class TestScenarioSeedFiles:
+    def test_scenario_seed_steps_pass_param_validation(self) -> None:
+        """Every builtin scenario seed must satisfy ScenarioStepCreate.
+
+        Bad params in a seed file would otherwise only surface as a runtime
+        seeding error (regression: Fault Disconnect shipped max_drift=-50,
+        which the injector's magnitude clamp turned into a sign flip)."""
+        import json
+
+        from app.schemas.scenario import ScenarioStepCreate
+        from app.seed.loader import SCENARIOS_DIR
+
+        seed_files = sorted(SCENARIOS_DIR.glob("*.json"))
+        assert seed_files, "no scenario seed files found"
+        for seed_file in seed_files:
+            raw = json.loads(seed_file.read_text(encoding="utf-8"))
+            for step in raw["steps"]:
+                ScenarioStepCreate(**step)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1409,6 +1409,11 @@ Create a new scenario with steps.
 **Error cases:**
 - `404` -- template not found
 - `409` -- duplicate name for this template
+- `422` -- invalid step anomaly params: steps enforce the same rules as
+  real-time injection and schedules (required params per anomaly type;
+  spike `multiplier > 0`, `probability` in [0,1]; drift `max_drift > 0` —
+  `max_drift` is a magnitude, drift direction comes from
+  `drift_per_second`'s sign). Applies to create, update, and import.
 
 ---
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,42 @@
 # Development Log
 
+## 2026-06-11 — Scenario step 參數驗證 + 負值 max_drift seed 修正
+
+### 根因
+
+/simplify 審查時發現 `ScenarioStepCreate` 缺少 anomaly 參數驗證（injection 與
+schedule 都有），追查後發現這不只是驗證缺口，而是已造成一個**真 bug**：
+
+`anomaly_injector._apply_anomaly` 的 drift clamp 是
+`if abs(drift) > abs(max_drift): drift = max_drift if drift_rate >= 0 else -max_drift`
+——`max_drift` 的設計語義是**幅度**（方向由 `drift_per_second` 正負號決定）。
+內建 seed「Fault Disconnect」卻寫了 `max_drift: -50`：dc_voltage 以 -5/s 下垂
+10 秒到 -50 後，clamp 取 `-max_drift = +50`，**瞬間反向跳 100V**，剩餘 18 秒
+掛在基準值上方。schedule 那邊的 `max_drift > 0` 驗證規則一直是對的，scenario
+只是漏了驗證才讓壞參數溜進 seed。
+
+### 修法（Ken 裁決採 B：修 seed + 統一驗證）
+
+1. `schemas/anomaly.py` 抽出 `AnomalyParamsBase`（anomaly_type + validate_params），
+   `AnomalyInjectRequest` / `AnomalyScheduleCreate` / `ScenarioStepCreate` 三個
+   schema 繼承——順便消掉原本 inject/schedule 兩份逐字重複的驗證器。
+2. seed 改 `max_drift: 50`（方向已由 `drift_per_second: -5` 表達）。
+3. **Alembic data migration `a7c3e91f4b20`**：seed loader 對已存在的 builtin
+   scenario 會跳過，所以已部署環境（Linode）的壞 row 要靠 migration 修——
+   只動 builtin scenario 的 drift step（`abs()` 修正），使用者自建的 scenario
+   不碰（API 層從此會擋新的負值，但既有資料尊重原樣）。
+4. 測試：injector 負向 drift 飽和不反轉的 regression test、scenario API 參數
+   驗證 422 測試、seed 檔全數通過 `ScenarioStepCreate` 的守門測試。另修兩個
+   既有測試（它們用空 params 的 spike/drift 觸發其他 422 路徑，新驗證會搶先
+   擋下，補上有效參數讓原本的測試目標仍被覆蓋）。
+
+### 驗證
+
+- Migration 以本地假資料實測：builtin `-50 → 50`、user scenario `-30` 不動、
+  非 drift step 不動；`alembic stamp` 後重跑 upgrade 確認可重入。
+- `pytest tests/test_scenarios.py tests/test_seed.py tests/test_anomaly_injector.py
+  tests/test_anomaly_api.py` → 47 passed；ruff clean。
+
 ## 2026-06-11 — Cut release 0.4.0 準備（Milestone 8.7）
 
 ### 做了什麼


### PR DESCRIPTION
## Summary

裁決二（Ken 拍板選 B）的實作。詳見 `docs/development-log.md` 2026-06-11 條目。

### 根因
`max_drift` 在 injector 的設計語義是**幅度**（方向由 `drift_per_second` 符號決定），clamp 寫法 `drift = max_drift if drift_rate >= 0 else -max_drift`。內建 seed「Fault Disconnect」用了 `max_drift: -50` → dc_voltage 下垂 10 秒到 -50 後 clamp 取 `-(-50) = +50`,**瞬間反向跳 100V**,剩餘 18 秒掛在基準值上方。

### 修正
- seed 改 `max_drift: 50`
- **Alembic data migration `a7c3e91f4b20`**:修復已部署環境中已 seed 的 builtin row(seed loader 對既存 scenario 會跳過,光改 JSON 修不到 Linode);只動 builtin,使用者自建 scenario 不碰
- `ScenarioStepCreate` 繼承新抽出的 `AnomalyParamsBase`,與 injection / schedule 共用同一套參數驗證(同時消掉 anomaly.py 裡兩份逐字重複的 validator);scenario create/update/import 對壞參數回 422
- API 文件補 422 說明

### 驗證
- Migration 以本地假資料實測:builtin `-50 → 50` ✓、user `-30` 不動 ✓、非 drift step 不動 ✓
- `pytest test_scenarios/test_seed/test_anomaly_injector/test_anomaly_api` → **47 passed**;ruff clean
- 既有測試中兩個用空 params 的 422 測試已補有效參數,確保原測試目標(register 檢查、overlap 檢查)仍被覆蓋

🤖 Generated with [Claude Code](https://claude.com/claude-code)