### PR TITLE
chore: cut release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-11
+
 ### Fixed
 - **OPC UA delay fault no longer blocks the event loop**: the delay was a `time.sleep` inside asyncua's synchronous value callback, so while one client read a delay-faulted node, every other protocol server, the REST API, the WebSocket broadcast and all simulation ticks stalled for up to 10 s (a 1 Hz poller re-triggered it continuously). The sleep now runs in an async `CallbackType.PreRead` server callback, suspending only the requesting session. Verified by a regression test that keeps a 50 ms heartbeat ticking during a 1.2 s delayed read.
 - **Builtin "Fault Disconnect" scenario flipped dc_voltage upward mid-step**: the seed used `max_drift: -50`, but `max_drift` is a magnitude — the injector clamps with `abs(drift) > abs(max_drift)` and takes the direction from `drift_per_second`'s sign, so once the cap was reached (10 s into the 28 s step) the clamp produced `-max_drift = +50` and the intended -50 V sag jumped to +50 V above baseline for the remaining 18 s. Seed fixed to `max_drift: 50`; Alembic data migration `a7c3e91f4b20` repairs already-seeded builtin rows (user scenarios untouched).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Multi-protocol device simulator for energy management systems.
 
-[![Version](https://img.shields.io/badge/version-0.4.0-blue)]()
+[![Version](https://img.shields.io/badge/version-0.4.1-blue)]()
 [![Python](https://img.shields.io/badge/python-3.12+-blue)]()
 [![License](https://img.shields.io/badge/license-MIT-green)]()
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
 
     # App
     APP_NAME: str = "GhostMeter"
-    APP_VERSION: str = "0.4.0"
+    APP_VERSION: str = "0.4.1"
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
 

--- a/docs/development-phases.md
+++ b/docs/development-phases.md
@@ -288,7 +288,10 @@
 - [x] Pre-release /simplify cleanup pass over `main...dev`: 14 behavior-preserving fixes applied (adapter fault-type capability, shared device-runtime registration, SNMP one-phase name map, frontend anomaly constants, monitor history/render perf, CSS-variable theming, test helper consolidation) — see dev log 2026-06-11; 5 findings deferred (OPC UA blocking delay, scenario param validation semantics, monitor DB cache, fault-action resolver, adapter_status generalization)
 - [x] Backend test health check: full `pytest` run **380 passed, 0 skipped** (2026-06-11, host venv vs ghostmeter_test DB)
 - [x] Cut release prep: version aligned to **0.4.0** everywhere (README badge was 0.3.0; backend `APP_VERSION` and frontend `package.json` were still 0.1.0); CHANGELOG `[Unreleased]` consolidated into a `[0.4.0] - 2026-06-11` section (duplicate subsection headers from successive pushes merged); README features list gained Scenario mode
-- [ ] Verify CI pipeline green on release PRs, merge to dev, then dev→main PR + `v0.4.0` tag (human review)
+- [x] **v0.4.0 released** (2026-06-11): PRs #47/#48/#49 merged with CI green, `v0.4.0` tag + GitHub Release published
+- [x] Deferred /simplify findings resolved per Ken's rulings: **PR #50** (negative max_drift seed bug — sign flip at the clamp — fixed + Alembic data repair + unified `AnomalyParamsBase` validation across inject/schedule/scenario) and **PR #51** (OPC UA delay fault moved to async PreRead hook — no longer blocks the event loop; red-test verified)
+- [x] **v0.4.1 released** (2026-06-11): the two fixes above
+- [ ] Remaining follow-ups (no decision needed): monitor_service per-tick DB query caching, per-adapter fault decision trees → shared resolver, MQTT-specific monitor payload fields → generic adapter_status, monitorStore singleton WS connection
 - [ ] Address issues surfaced during audit: #21 (Cloudflare Pages build config), #22 (npm audit vulnerabilities), #23 (frontend bundle >500KB)
 
 ---

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "antd": "^6.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

0.4.1 patch release cut:兩個裁決修正(#50 drift seed sign-flip bug + 驗證統一、#51 OPC UA delay 非阻塞)。

- CHANGELOG `[Unreleased]` → `[0.4.1] - 2026-06-11`
- 版本號 bump:README badge / backend `APP_VERSION` / frontend `package.json` → 0.4.1
- phases 文件記錄 v0.4.0 釋出完成與兩項裁決修正

Merge 後:dev→main PR,merge 後打 `v0.4.1` tag(我會接續執行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)