### PR TITLE
chore: cut release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-11
+
 ### Fixed
 - **Builtin scenarios never seeded in any environment**: the scenario seed JSONs referenced template names that don't exist in the template seeds (`Solar Inverter (Fronius Symo)` / `Three-Phase Power Meter (SDM630)` vs. the actual `SunSpec Solar Inverter` / `SDM630 Three-Phase Meter`), and `seed_builtin_scenarios` only logs a WARNING on a miss — so every deployment shipped with zero builtin scenarios. Seed names fixed; two guard tests added (static cross-reference of scenario seeds against template seeds, and an end-to-end seed test asserting the builtin scenarios actually land).
 - `.env.example` no longer pins `APP_VERSION=0.1.0` — the value overrode the application's real version via pydantic-settings, making deployed instances report a stale version at `/health`. The version is a code constant, not deployment config.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Multi-protocol device simulator for energy management systems.
 
-[![Version](https://img.shields.io/badge/version-0.4.1-blue)]()
+[![Version](https://img.shields.io/badge/version-0.4.2-blue)]()
 [![Python](https://img.shields.io/badge/python-3.12+-blue)]()
 [![License](https://img.shields.io/badge/license-MIT-green)]()
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
 
     # App
     APP_NAME: str = "GhostMeter"
-    APP_VERSION: str = "0.4.1"
+    APP_VERSION: str = "0.4.2"
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "antd": "^6.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

0.4.2 patch release cut:#54(內建 scenario seed 名稱漂移修正 + 守門測試、`.env.example` 移除 APP_VERSION)。

- CHANGELOG `[Unreleased]` → `[0.4.2] - 2026-06-11`
- 版本號 bump 至 0.4.2(README badge / backend / frontend)

Merge 後:dev→main PR → `v0.4.2` tag + GitHub Release(接續執行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)