### PR TITLE
docs: README SSH alias tip for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ cd ~/ghostmeter && ./update.sh
 [`docs/deployment.md`](docs/deployment.md) for the full guide (Tailscale +
 Cloudflare Tunnel).
 
+Tip: define an SSH alias for the deploy host in your private `~/.ssh/config`
+(host/IP and key stay out of the repo), then updating is one command from
+anywhere:
+
+```bash
+ssh <alias>                                    # key-authed login
+ssh <alias> 'cd ~/ghostmeter && ./update.sh'   # one-shot update + redeploy
+```
+
 ## Tech Stack
 
 | Layer | Technology |


### PR DESCRIPTION
README Deployment 區段補充 SSH alias 用法(`ssh <alias>` 登入、`ssh <alias> 'cd ~/ghostmeter && ./update.sh'` 一鍵更新)。

Repo 是 public,實際 IP / root 帳號 / alias 名稱刻意不寫進 repo——只示意「把連線資訊放在私人 `~/.ssh/config`」的模式;實際連線指令記錄在本機 memory(Ken 已確認此寫法)。

純 README 變更,CHANGELOG/其他文件無關故略過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)