### PR TITLE
fix: Monitor WS same-origin (works behind proxy/tunnel, no hardcoded :8000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Monitor WebSocket now connects same-origin** (`wss://`/`ws://` + current host + `/ws/monitor`) instead of hardcoding `ws://<hostname>:8000`. The dev server (vite `/ws` proxy) and production nginx (`location /ws/`) have always proxied WebSocket traffic, but the client bypassed them — so live values only worked when the backend port was directly reachable (Tailscale), and broke behind any reverse proxy or HTTPS tunnel (mixed-content `ws://` is blocked on https pages).
+
 ## [0.4.2] - 2026-06-11
 
 ### Fixed

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,35 @@
 # Development Log
 
+## 2026-06-11 — Monitor WS 改 same-origin（P0 安全盤點的修正項）
+
+### 盤點結論（先於修正）
+
+針對「API 無認證但公網可達」的 P0 疑慮做了實地查證：
+
+- Linode 上**沒有** Cloudflare Tunnel（無 cloudflared 容器/程序/token）——
+  API 與前端只綁 Tailscale IP，公網不可達，風險不成立。
+- `ghostmeter.pages.dev` 是活的（CI 的 Cloudflare Pages 整合每次 push 自動
+  部署），但其 `/api` 打回 SPA fallback——是個無後端的壞 UI 殼（= issue #21），
+  無資料暴露。處置（停用 Pages 專案或加 Access）需在 Cloudflare dashboard
+  操作，記錄於 issue。
+
+### 修正：WS 硬編碼 :8000
+
+`MONITOR_WS_URL` 硬編碼 `ws://<hostname>:8000`，但 vite dev（`/ws` proxy）
+與 production nginx（`location /ws/`）其實都早已支援 WS 代理——client 繞過
+它們導致：(a) 任何 reverse proxy / tunnel 後面 Monitor 即時值都是死的；
+(b) https 頁面上 `ws://` 會被瀏覽器以 mixed content 擋掉。改為 same-origin
+（協議依 `location.protocol` 切 wss/ws）。
+
+### 驗證
+
+- `npm run build` 通過。
+- 本地 production nginx 容器（:3002）實測 WS upgrade：
+  `curl -H "Upgrade: websocket" ... http://localhost:3002/ws/monitor` →
+  **HTTP/1.1 101 Switching Protocols**。
+- 部署 Linode 後以 Tailscale IP:3002 再驗一次 101。
+
+
 ## 2026-06-11 — 內建 scenario 從未 seed 成功 + .env 版本覆寫（v0.4.1 部署驗證發現）
 
 ### 根因

--- a/frontend/src/services/ws.ts
+++ b/frontend/src/services/ws.ts
@@ -1,2 +1,10 @@
-/** WebSocket endpoint for the realtime monitor broadcast (1 Hz). */
-export const MONITOR_WS_URL = `ws://${window.location.hostname}:8000/ws/monitor`;
+/** WebSocket endpoint for the realtime monitor broadcast (1 Hz).
+ *
+ * Same-origin on purpose: the dev server (vite proxy "/ws") and the
+ * production nginx (location /ws/) both proxy WebSocket traffic to the
+ * backend, so the client must NOT hardcode the backend host/port — a
+ * hardcoded ws://host:8000 breaks behind any reverse proxy or tunnel,
+ * and ws:// is blocked as mixed content on https pages.
+ */
+const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
+export const MONITOR_WS_URL = `${wsProtocol}://${window.location.host}/ws/monitor`;


### PR DESCRIPTION
## Summary

P0 盤點(詳見 dev log 2026-06-11)的程式碼修正項:

- **盤點結論**:Linode 無 Cloudflare Tunnel,API 僅 Tailscale 可達 → 「API 無認證公開」不成立;`ghostmeter.pages.dev` 是無後端的壞 UI 殼(issue #21),處置需在 Cloudflare dashboard。
- **修正**:`MONITOR_WS_URL` 硬編碼 `ws://<hostname>:8000` → 改 same-origin(`wss/ws` 依頁面協議)。vite 與 nginx 的 `/ws` 代理一直都在,client 卻繞過,導致 proxy/tunnel 後面 Monitor 即時值全死、https 頁面被 mixed-content 擋。

## 驗證
- `npm run build` ✓
- 本地 production nginx(:3002)WS upgrade 實測 → **101 Switching Protocols** ✓
- Merge 後部署 Linode,以 Tailscale :3002 再驗

🤖 Generated with [Claude Code](https://claude.com/claude-code)