### PR TITLE
feat: built-in Cloudflare Tunnel support (opt-in cloudflared sidecar)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,11 @@ VITE_API_BASE_URL=http://localhost:8000
 # Tailscale IP so services are reachable over the tailnet but NOT the public
 # Internet. Leave empty for local dev (defaults to 127.0.0.1).
 BIND_IP=
+
+# Cloudflare Tunnel (optional, deploy hosts only)
+# Set the token from Zero Trust -> Networks -> Tunnels to publish the app
+# through Cloudflare WITHOUT opening inbound ports. deploy.sh starts the
+# cloudflared sidecar only when this is non-empty.
+# SECURITY: configure a Cloudflare Access policy for the Public Hostname
+# BEFORE setting this — the API itself has no authentication.
+CLOUDFLARE_TUNNEL_TOKEN=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Built-in Cloudflare Tunnel support** for deploy hosts: `docker-compose.prod.yml` gains an opt-in `cloudflared` sidecar (compose profile `tunnel`); `deploy.sh` enables it only when `CLOUDFLARE_TUNNEL_TOKEN` is set in `.env`, so tokenless deployments are unaffected. Deployment guide rewritten with the full Zero Trust procedure — **a Cloudflare Access policy is mandatory before exposing a Public Hostname** (the API has no authentication of its own).
+
 ### Fixed
 - **Monitor WebSocket now connects same-origin** (`wss://`/`ws://` + current host + `/ws/monitor`) instead of hardcoding `ws://<hostname>:8000`. The dev server (vite `/ws` proxy) and production nginx (`location /ws/`) have always proxied WebSocket traffic, but the client bypassed them — so live values only worked when the backend port was directly reachable (Tailscale), and broke behind any reverse proxy or HTTPS tunnel (mixed-content `ws://` is blocked on https pages).
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,6 +24,14 @@ fi
 
 COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.prod.yml)
 
+# Enable the Cloudflare Tunnel sidecar only when a token is configured in
+# .env (see docs/deployment.md section 5 — an Access policy must be set up
+# in Cloudflare Zero Trust BEFORE exposing a Public Hostname).
+if grep -q '^CLOUDFLARE_TUNNEL_TOKEN=..*' .env; then
+  export COMPOSE_PROFILES=tunnel
+  echo "==> Cloudflare Tunnel enabled (CLOUDFLARE_TUNNEL_TOKEN is set)"
+fi
+
 echo "==> Building backend and frontend images"
 "${COMPOSE[@]}" build backend frontend
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,3 +30,25 @@ services:
   frontend:
     ports: !override
       - "${BIND_IP:-127.0.0.1}:3002:80"
+
+  # Cloudflare Tunnel sidecar — publishes the frontend (and, through nginx's
+  # /api + /ws proxies, the whole app) over a Cloudflare hostname WITHOUT
+  # opening any inbound port (cloudflared dials out to Cloudflare).
+  #
+  # Opt-in via compose profile: deploy.sh enables the "tunnel" profile only
+  # when CLOUDFLARE_TUNNEL_TOKEN is set in .env, so deployments without a
+  # token are completely unaffected.
+  #
+  # SECURITY: the API has no authentication of its own. Before pointing a
+  # Public Hostname at this tunnel, an Access policy MUST be configured in
+  # Cloudflare Zero Trust — otherwise anyone with the URL controls the
+  # simulator. See docs/deployment.md section 5.
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    profiles: ["tunnel"]
+    command: tunnel run
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN:-}
+    restart: unless-stopped
+    depends_on:
+      - frontend

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,23 +55,42 @@ http --timeout=5 http://<公網IP>:8000/health        # ✅ 應 timeout = 沒裸
 
 協議埠測試:用 EMS / 工具連 `<BIND_IP>` 的 `502`(Modbus)、`4840`(OPC UA)、`161`(SNMP)。
 
-## 5. 前端對外(Cloudflare Tunnel)
+## 5. 前端對外(Cloudflare Tunnel + Access)
 
-公網埠全鎖,所以用 **Cloudflare Tunnel**(純出站,不開任何入站埠)對外發布前端。在 Zero Trust → Networks → Tunnels 建 tunnel 取得 token,於 VM 加一個 service(可放 `docker-compose.override.yml` 或併入 prod overlay):
+公網埠全鎖,所以用 **Cloudflare Tunnel**(純出站,不開任何入站埠)對外發布。
+cloudflared sidecar 已內建在 `docker-compose.prod.yml`(profile `tunnel`),
+`deploy.sh` 偵測到 `.env` 有 `CLOUDFLARE_TUNNEL_TOKEN` 才會啟動它——沒設 token
+的部署完全不受影響。
 
-```yaml
-services:
-  cloudflared:
-    image: cloudflare/cloudflared:latest
-    command: tunnel run
-    environment:
-      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}
-    restart: unless-stopped
-    depends_on:
-      - frontend
+> ⚠️ **先設 Access 再開 Hostname**。nginx 會把 `/api` 與 `/ws` 一併 proxy 給
+> backend,而 API 本身沒有任何認證——Public Hostname 沒有 Access policy 擋著,
+> 等於任何知道網址的人都能操控模擬器。
+
+### Dashboard 端(Cloudflare Zero Trust)
+
+1. **建 Tunnel**:Networks → Tunnels → Create a tunnel(connector 選
+   cloudflared)→ 複製 token(`eyJ...` 長字串)。
+2. **設 Public Hostname**:該 tunnel → Public Hostname → 你的網域/子網域 →
+   service 填 `http://frontend:80`(同 compose network,用服務名)。
+3. **設 Access policy(必做)**:Access → Applications → Add an application →
+   Self-hosted → domain 填同一個 hostname → policy 設 Allow + Include →
+   Emails → 你的 email。之後開網址會先看到 Cloudflare 登入頁(email OTP)。
+
+### VM 端
+
+```bash
+echo 'CLOUDFLARE_TUNNEL_TOKEN=eyJ...' >> ~/ghostmeter/.env
+cd ~/ghostmeter && ./update.sh        # deploy.sh 偵測 token → 啟動 cloudflared
+docker logs ghostmeter-cloudflared-1 | tail   # 應看到 "Registered tunnel connection"
 ```
 
-在 tunnel 的 Public Hostname 設定你的網域 → service `http://frontend:80`(同 compose network 用服務名),即取得公網 HTTPS 前端,且不暴露任何協議埠。
+### 驗證
+
+- 開 `https://<你的網域>` → 先被導到 Cloudflare Access 登入,通過後看到 UI
+- Monitor 頁即時值正常(WS 走 same-origin `wss://<網域>/ws/monitor`,經 nginx
+  proxy;v0.4.2 之後支援)
+- 無痕視窗直接打 `https://<網域>/api/v1/templates` → 應被 Access 擋下(302 到
+  登入頁),拿不到 JSON
 
 ## 相關檔案
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,33 @@
 # Development Log
 
+## 2026-06-11 — Cloudflare Tunnel 內建支援（opt-in sidecar）
+
+### 做了什麼
+
+Ken 確認理想架構為「公網 → Cloudflare Access → Tunnel → Linode frontend（nginx
+proxy /api、/ws）」。盤點確認 Linode 本來就有完整前端（nginx :3002，僅
+Tailscale 可達），Pages 那份是 CI 副產品壞殼（issue #21，待 dashboard 停用）。
+
+實作（VM/repo 端；dashboard 端由 Ken 操作）：
+
+- `docker-compose.prod.yml` 新增 `cloudflared` sidecar，掛 compose profile
+  `tunnel`——profile 未啟用時 `config --services` 驗證不含該服務，行為不變。
+- `deploy.sh` 偵測 `.env` 的 `CLOUDFLARE_TUNNEL_TOKEN` 非空才 export
+  `COMPOSE_PROFILES=tunnel`（grep 邏輯以空值/有值兩種 .env 實測過）。
+- `.env.example` 新增 `CLOUDFLARE_TUNNEL_TOKEN=`（含安全警語）。
+- `docs/deployment.md` 第 5 節改寫為完整流程：dashboard 三步（建 tunnel、
+  Public Hostname → `http://frontend:80`、**Access policy 必設**）+ VM 端
+  一行 token + `update.sh` + 驗證清單（含無痕打 `/api` 應被 Access 擋）。
+
+### 設計取捨
+
+- 用 compose profile 而非獨立 override 檔：單一檔案、deploy.sh 一個 if、
+  token 不存在時零影響（與 BIND_IP 預設 127.0.0.1 的 fail-safe 哲學一致）。
+- 認證放 Cloudflare Access 而非應用層 API key：零程式碼、天然涵蓋 `/api` 與
+  `/ws` 全路徑、SSO/OTP 現成。應用層認證等真正多用戶需求出現再說。
+- WS 經 tunnel 可用的前提是 same-origin（PR #58）已先落地。
+
+
 ## 2026-06-11 — Monitor WS 改 same-origin（P0 安全盤點的修正項）
 
 ### 盤點結論（先於修正）


### PR DESCRIPTION
## Summary

實現 Ken 確認的理想架構:**公網 → Cloudflare Access → Tunnel → Linode frontend(nginx proxy `/api`、`/ws`)**。VM/repo 端全部就緒,dashboard 端三步由 Ken 操作。

- `docker-compose.prod.yml`:`cloudflared` sidecar 掛 compose profile `tunnel`(opt-in)
- `deploy.sh`:`.env` 的 `CLOUDFLARE_TUNNEL_TOKEN` 非空才啟用 profile —— 沒 token 的部署完全不變
- `.env.example`:新增 token 欄位 + 安全警語
- `docs/deployment.md` §5 改寫:dashboard 三步(建 tunnel / Public Hostname → `http://frontend:80` / **Access policy 必設**)+ VM 端步驟 + 驗證清單

## 驗證
- `docker compose config --services`:無 profile → 3 服務(無 cloudflared);有 profile → 4 服務 ✓
- `deploy.sh` 的 grep 啟用邏輯:空 token 不觸發、有 token 觸發 ✓;`bash -n` 語法檢查 ✓
- 實際 tunnel 連線需 token,待 Ken 在 Zero Trust 建好後:`echo 'CLOUDFLARE_TUNNEL_TOKEN=...' >> .env && ./update.sh`,驗證清單在文件裡

## ⚠️ 上線順序
**先設 Access policy,再開 Public Hostname** —— API 自身無認證,順序反了等於公網裸奔(文件與 compose 註解都有警語)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)