### PR TITLE
fix: remove fake "Live" badge from app header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Built-in Cloudflare Tunnel support** for deploy hosts: `docker-compose.prod.yml` gains an opt-in `cloudflared` sidecar (compose profile `tunnel`); `deploy.sh` enables it only when `CLOUDFLARE_TUNNEL_TOKEN` is set in `.env`, so tokenless deployments are unaffected. Deployment guide rewritten with the full Zero Trust procedure — **a Cloudflare Access policy is mandatory before exposing a Public Hostname** (the API has no authentication of its own).
 
+### Removed
+- **Fake "Live" badge in the app header**: it was static decoration — always glowing regardless of actual WebSocket state — and its height overflowed the 64px header (antd's inherited `line-height: 64px` + badge padding). The real connection indicator lives on the Monitor page title (green "Live" / red "Disconnected", bound to WS state).
+
 ### Fixed
 - **Monitor WebSocket now connects same-origin** (`wss://`/`ws://` + current host + `/ws/monitor`) instead of hardcoding `ws://<hostname>:8000`. The dev server (vite `/ws` proxy) and production nginx (`location /ws/`) have always proxied WebSocket traffic, but the client bypassed them — so live values only worked when the backend port was directly reachable (Tailscale), and broke behind any reverse proxy or HTTPS tunnel (mixed-content `ws://` is blocked on https pages).
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,30 @@
 # Development Log
 
+## 2026-06-12 — 移除 header 假 Live badge
+
+### 問題
+
+Ken 回報右上角 LIVE 格子超出 header 底線，並質疑它的實際功用。查證結果：
+
+1. **跑版根因**：antd `.ant-layout-header` 預設 `line-height: 64px` 被 badge
+   內的 `<span>Live</span>` 繼承，inline-flex 子元素高度由 line box 決定，
+   加上 badge 自身 `padding: 4px` 後整體約 72px，超過 64px 的 header。
+2. **更根本的問題**：這顆 badge 是純靜態裝飾（`MainLayout.tsx`），沒綁任何
+   state——WS 斷線、backend 掛掉時照樣亮綠燈，是會誤導的假指示燈。真正的
+   連線指示在 Monitor 頁標題旁（綁 WS `connected`，斷線變紅）。
+
+### 處置
+
+Ken 裁示方案 A：直接移除（而非接上 monitorStore 變成真指示燈）。理由：真
+指示燈 Monitor 頁已有，header 重複一顆資訊價值低。
+
+- `MainLayout.tsx` 移除 badge JSX
+- `global.css` 移除 `.gm-header-live`、`.gm-header-live-dot`、`@keyframes
+  gm-pulse`（grep 確認僅此 badge 使用）
+
+驗證：`npm run build` 通過；bundle 內 grep 無 `gm-header-live`/`gm-pulse` 殘留。
+
+
 ## 2026-06-11 — Cloudflare Tunnel 內建支援（opt-in sidecar）
 
 ### 做了什麼

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -70,10 +70,6 @@ export function MainLayout() {
             }
             onClick={toggleSidebar}
           />
-          <span className="gm-header-live">
-            <span className="gm-header-live-dot" />
-            <span>Live</span>
-          </span>
         </Header>
         <Content className="gm-content">
           <Outlet />

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -142,39 +142,6 @@ samp {
   justify-content: space-between;
 }
 
-.gm-header-live {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 10px;
-  border-radius: 6px;
-  background: rgba(34, 211, 238, 0.08);
-  border: 1px solid rgba(34, 211, 238, 0.22);
-  font-family: var(--gm-mono);
-  font-size: 11px;
-  color: var(--gm-cyan);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.gm-header-live-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--gm-cyan);
-  box-shadow: 0 0 8px var(--gm-cyan);
-  animation: gm-pulse 1.8s ease-in-out infinite;
-}
-
-@keyframes gm-pulse {
-  0%, 100% {
-    box-shadow: 0 0 0 0 rgba(34, 211, 238, 0.7);
-  }
-  70% {
-    box-shadow: 0 0 0 8px rgba(34, 211, 238, 0);
-  }
-}
-
 .gm-content {
   margin: 20px !important;
   padding: 24px !important;


### PR DESCRIPTION
## 問題

Ken 回報兩件事:
1. 右上角 LIVE 格子超出 header 底線
2. 質疑 LIVE 的實際功用

## 根因

1. **跑版**:antd `.ant-layout-header` 預設 `line-height: 64px` 被 badge 內文字繼承,badge(inline-flex + 4px padding)被撐到 ~72px,超過 64px header。
2. **假指示燈**:badge 是純靜態 JSX,沒綁任何 state——WS 斷線時照樣亮綠燈。真正的連線指示在 Monitor 頁標題旁(綁 WS `connected`,斷線顯示紅色 Disconnected)。

## 處置(Ken 裁示方案 A)

直接移除,不接 state——真指示燈 Monitor 頁已有,header 重複一顆資訊價值低:

- `MainLayout.tsx`:移除 badge JSX
- `global.css`:移除 `.gm-header-live` / `.gm-header-live-dot` / `@keyframes gm-pulse`(grep 確認僅此 badge 使用)

## 驗證

- `npm run build` ✅(326ms, 3687 modules)
- bundle 內 grep `gm-header-live|gm-pulse|>Live<` 無殘留 ✅
- Monitor 頁的真 Live badge 不受影響(獨立的 antd `Badge` 元件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)