### PR TITLE
docs: team member access guide (Cloudflare Access + Tailscale node sharing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Documentation
+- Deployment guide: new "team member access" coverage — add teammate emails to the Cloudflare Access policy for Web UI/API, and share the Linode via **Tailscale node sharing** (single-machine share, no tailnet membership needed) for the protocol ports (Modbus 502 / OPC UA 4840 / SNMP 161), including Windows client setup and connectivity checks.
+
 ### Added
 - **Built-in Cloudflare Tunnel support** for deploy hosts: `docker-compose.prod.yml` gains an opt-in `cloudflared` sidecar (compose profile `tunnel`); `deploy.sh` enables it only when `CLOUDFLARE_TUNNEL_TOKEN` is set in `.env`, so tokenless deployments are unaffected. Deployment guide rewritten with the full Zero Trust procedure — **a Cloudflare Access policy is mandatory before exposing a Public Hostname** (the API has no authentication of its own).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -75,6 +75,8 @@ cloudflared sidecar 已內建在 `docker-compose.prod.yml`(profile `tunnel`),
 3. **設 Access policy(必做)**:Access → Applications → Add an application →
    Self-hosted → domain 填同一個 hostname → policy 設 Allow + Include →
    Emails → 你的 email。之後開網址會先看到 Cloudflare 登入頁(email OTP)。
+   要讓 team member 用 Web UI,把他們的 email 一併加進這個 policy 即可
+   (對方不需要 Cloudflare 帳號;同網域的人可改用 Emails ending in 一條涵蓋)。
 
 ### VM 端
 
@@ -91,6 +93,41 @@ docker logs ghostmeter-cloudflared-1 | tail   # 應看到 "Registered tunnel con
   proxy;v0.4.2 之後支援)
 - 無痕視窗直接打 `https://<網域>/api/v1/templates` → 應被 Access 擋下(302 到
   登入頁),拿不到 JSON
+
+## 6. 協議埠給 team member(Tailscale Node Sharing)
+
+協議埠(`502` Modbus、`4840` OPC UA、`161` SNMP)只綁在 Tailscale IP 上,
+team member 要用 EMS / 工具連設備,必須走 tailnet。用 **node sharing**
+只分享 Linode 這一台機器,不必把人加進自己的 tailnet:
+
+- 對方**只看得到這一台**,tailnet 裡其他裝置對他不存在
+- 不佔免費方案的 user 名額,分享人數不限
+- 被分享的機器預設被隔離,不能主動連回對方的網路
+
+> 如果 team member 需要連多台機器或要雙向互連,才考慮改用
+> 「邀請加入 tailnet」(免費方案上限 6 人,建議搭配 ACL group 限制權限)。
+
+### 分享端(你)
+
+1. [Admin console](https://login.tailscale.com/admin/machines) → Machines →
+   Linode 那台 → ⋯ → **Share** → Copy share link 傳給對方(30 天有效)
+2. 把機器的 Tailscale IP(`tailscale ip -4`,100.x.x.x)給對方
+
+### 接收端(team member)
+
+1. 點分享連結 → 用任何 email(Google / Microsoft / GitHub)註冊或登入
+   Tailscale → 接受分享
+2. 裝 Tailscale client 並登入**同一個帳號**
+   (Windows:<https://tailscale.com/download/windows> 或
+   `winget install tailscale.tailscale`)
+3. EMS / 工具的設備 IP 填 Linode 的 Tailscale IP,例如 Modbus 連
+   `<Tailscale IP>:502`
+
+### 驗證與管理
+
+- Windows 連線測試:`Test-NetConnection <Tailscale IP> -Port 502`
+- 連不上最常見原因:登入的帳號跟接受邀請的帳號不同
+- 收回權限:Machines → 該機器 → ⋯ → Share → 移除該 user,不影響其他人
 
 ## 相關檔案
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,28 @@
 # Development Log
 
+## 2026-06-12 — 部署文件補 team member 存取章節
+
+### 背景
+
+Ken 要讓 team member 連 GhostMeter：Web UI 走 Cloudflare、協議埠（502/4840/161）
+走 Tailscale。討論釐清兩個常見誤解：
+
+1. **Cloudflare**：不是把對方 email 加成 Cloudflare 帳號成員（那是 dashboard
+   管理權限），而是加進 Zero Trust 的 **Access policy**（對方不需要 Cloudflare
+   帳號，登入走 email OTP）。
+2. **Tailscale**：協議埠只綁 Tailscale IP，對方必須走 tailnet。比較後選
+   **node sharing**（只分享 Linode 單機）而非邀請進 tailnet——最小權限、
+   不佔免費方案 6 人名額、被分享機器預設隔離不能反連。
+
+### 處置
+
+- `docs/deployment.md` 第 5 節 Access policy 步驟補「加 team member email /
+  同網域用 Emails ending in」說明
+- 新增第 6 節「協議埠給 team member（Tailscale Node Sharing）」：分享端、
+  接收端（含 Windows 安裝）、驗證與收回權限步驟
+
+純文件變更，無程式碼異動。
+
 ## 2026-06-12 — 移除 header 假 Live badge
 
 ### 問題


### PR DESCRIPTION
## Summary

純文件變更——把這次討論的 team member 存取做法記錄進部署指南：

- **`docs/deployment.md` 第 5 節**：Access policy 步驟補充「team member email 加進 policy 即可（不是加成 Cloudflare 帳號成員）；同網域可用 Emails ending in」
- **`docs/deployment.md` 新增第 6 節**：協議埠（Modbus 502 / OPC UA 4840 / SNMP 161）走 **Tailscale node sharing** 分享給 team member——只分享 Linode 單機、不佔免費方案名額、含 Windows client 安裝與 `Test-NetConnection` 驗證、收回權限步驟
- CHANGELOG 與 development-log 同步更新

無程式碼異動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)