### PR TITLE
fix: resolve all 14 pre-existing ESLint problems (issue #63)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ frontend/coverage/
 # Playwright artifacts
 frontend/test-results/
 frontend/playwright-report/
+.playwright-mcp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Fake "Live" badge in the app header**: it was static decoration — always glowing regardless of actual WebSocket state — and its height overflowed the 64px header (antd's inherited `line-height: 64px` + badge padding). The real connection indicator lives on the Monitor page title (green "Live" / red "Disconnected", bound to WS state).
 
 ### Fixed
+- **All 14 pre-existing ESLint problems fixed (12 errors / 2 warnings) — `npm run lint` is now clean** (issue #63). Highlights: `useWebSocket` rewrote its self-referencing reconnect closure into an effect-scoped lifecycle — the message handler now lives in a ref, so a changed callback identity no longer tears down and reopens the socket; six setState-in-effect occurrences replaced with derived state (`useMemo` base + user-edit overlay in DataModeTab / ProfileFormModal, derived default profile in CreateDeviceModal, async-init in TemplateForm); `handleExport` moved out of `ImportExportButtons.tsx` into `exportTemplate.ts` (react-refresh). WS reconnect verified end-to-end: Monitor shows Live → backend stopped → Disconnected → backend restarted → Live restores automatically.
+
 - **Monitor WebSocket now connects same-origin** (`wss://`/`ws://` + current host + `/ws/monitor`) instead of hardcoding `ws://<hostname>:8000`. The dev server (vite `/ws` proxy) and production nginx (`location /ws/`) have always proxied WebSocket traffic, but the client bypassed them — so live values only worked when the backend port was directly reachable (Tailscale), and broke behind any reverse proxy or HTTPS tunnel (mixed-content `ws://` is blocked on https pages).
 
 ## [0.4.2] - 2026-06-11

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,5 +1,40 @@
 # Development Log
 
+## 2026-06-12 — 修復 14 個既存 ESLint 問題（issue #63，P1）
+
+### 重點修復
+
+1. **`useWebSocket` 重寫**（唯一的真 bug 風險）：原本 `connect` useCallback 在
+   自己的 closure 裡引用自己（reconnect 的 setTimeout），React Compiler 拒絕
+   編譯且有 stale-closure 風險；另外 `onMessage` 在 deps 裡，callback identity
+   一變就整個斷線重連。改成：連線生命週期收進單一 effect（local function 自然
+   hoist 可自我引用）、`onMessage` 走 ref（handler 更新不再觸發重連）、
+   `disposed` flag 防止 unmount 後的 timer 重連。
+2. **六處 setState-in-effect** 改為 derived state：
+   - DataModeTab / ProfileFormModal：rows = `useMemo` 的 server-derived base +
+     user-edit overlay（`edits` keyed by register name），存檔/關閉時清 overlay
+   - CreateDeviceModal：default profile 改為 render 期 derive（`??` fallback），
+     關閉清理移到 `handleClose` 事件
+   - TemplateForm：`fetchTemplate` 改回傳資料，初始化收進 async effect
+     （順帶消掉 `_id` unused var）
+   - AnomalyTab / DataModeTab 的 register fetch 內聯進 effect（async IIFE +
+     cancelled flag）
+3. 其他：`UpdateTemplate` 空 interface → type alias；`handleExport` 搬出
+   component 檔成 `exportTemplate.ts`（react-refresh）；DeviceDetail 的
+   `useMemo` deps 抽出 optional chain；Mqtt 兩處 exhaustive-deps warning
+   內聯修正。
+
+### 驗證
+
+- `npm run lint` → **0 error 0 warning**；`npm run build` 通過
+- WS 重連 e2e 實測（Playwright + 本機 dev compose）：Monitor 顯示 Live →
+  `docker compose stop backend` → Disconnected → `start backend` → 自動恢復
+  Live，無需重整
+- TemplateForm 編輯頁實測：名稱/registers 正確載入（驗證新的 async 初始化）
+- DataModeTab 實測：rows 正確渲染、改 interval 只動該 row、Save All 後
+  server 回讀值正確、overlay 清空
+
+
 ## 2026-06-12 — 部署文件補 team member 存取章節
 
 ### 背景

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface UseWebSocketOptions {
   url: string;
@@ -13,64 +13,66 @@ export function useWebSocket({
   reconnectInterval = 1000,
   maxReconnectInterval = 30000,
 }: UseWebSocketOptions) {
-  const wsRef = useRef<WebSocket | null>(null);
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const reconnectDelayRef = useRef<number>(reconnectInterval);
   const [connected, setConnected] = useState<boolean>(false);
 
-  const connect = useCallback(() => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) return;
-
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
-
-    ws.onopen = () => {
-      setConnected(true);
-      reconnectDelayRef.current = reconnectInterval;
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        onMessage(data);
-      } catch {
-        // Ignore malformed messages
-      }
-    };
-
-    ws.onclose = () => {
-      setConnected(false);
-      wsRef.current = null;
-      // Exponential backoff reconnect
-      reconnectTimeoutRef.current = setTimeout(() => {
-        reconnectDelayRef.current = Math.min(
-          reconnectDelayRef.current * 2,
-          maxReconnectInterval,
-        );
-        connect();
-      }, reconnectDelayRef.current);
-    };
-
-    ws.onerror = () => {
-      ws.close();
-    };
-  }, [url, onMessage, reconnectInterval, maxReconnectInterval]);
+  // Keep the latest handler in a ref so a changed callback identity doesn't
+  // tear down and reopen the socket.
+  const onMessageRef = useRef(onMessage);
+  useEffect(() => {
+    onMessageRef.current = onMessage;
+  }, [onMessage]);
 
   useEffect(() => {
+    let ws: WebSocket | null = null;
+    let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
+    let reconnectDelay = reconnectInterval;
+    let disposed = false;
+
+    function connect() {
+      ws = new WebSocket(url);
+
+      ws.onopen = () => {
+        setConnected(true);
+        reconnectDelay = reconnectInterval;
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          onMessageRef.current(JSON.parse(event.data));
+        } catch {
+          // Ignore malformed messages
+        }
+      };
+
+      ws.onclose = () => {
+        setConnected(false);
+        if (disposed) return;
+        // Exponential backoff reconnect
+        reconnectTimeout = setTimeout(() => {
+          reconnectDelay = Math.min(reconnectDelay * 2, maxReconnectInterval);
+          connect();
+        }, reconnectDelay);
+      };
+
+      ws.onerror = () => {
+        ws?.close();
+      };
+    }
+
     connect();
 
     return () => {
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
+      disposed = true;
+      if (reconnectTimeout) {
+        clearTimeout(reconnectTimeout);
       }
-      if (wsRef.current) {
-        wsRef.current.onclose = null; // Prevent reconnect on intentional close
-        wsRef.current.close();
-        wsRef.current = null;
+      if (ws) {
+        ws.onclose = null; // Prevent reconnect on intentional close
+        ws.close();
       }
       setConnected(false);
     };
-  }, [connect]);
+  }, [url, reconnectInterval, maxReconnectInterval]);
 
   return { connected };
 }

--- a/frontend/src/pages/Devices/CreateDeviceModal.tsx
+++ b/frontend/src/pages/Devices/CreateDeviceModal.tsx
@@ -17,8 +17,10 @@ export function CreateDeviceModal({ open, onClose }: CreateDeviceModalProps) {
   const { createDevice, batchCreateDevices, fetchDevices } = useDeviceStore();
   const { profiles, loading: profilesLoading, fetchProfiles, clearProfiles } =
     useProfileStore();
+  // undefined = no explicit user choice; the default profile (derived below)
+  // applies until the user picks one.
   const [selectedProfileId, setSelectedProfileId] = useState<
-    string | null | undefined
+    string | undefined
   >(undefined);
 
   useEffect(() => {
@@ -27,23 +29,14 @@ export function CreateDeviceModal({ open, onClose }: CreateDeviceModalProps) {
     }
   }, [open, fetchTemplates]);
 
-  // Pre-select default profile when profiles load
-  useEffect(() => {
-    if (profiles.length > 0) {
-      const defaultProfile = profiles.find((p) => p.is_default);
-      setSelectedProfileId(defaultProfile?.id ?? undefined);
-    } else {
-      setSelectedProfileId(undefined);
-    }
-  }, [profiles]);
+  const defaultProfileId = profiles.find((p) => p.is_default)?.id;
+  const effectiveProfileId = selectedProfileId ?? defaultProfileId;
 
-  // Clean up on close
-  useEffect(() => {
-    if (!open) {
-      clearProfiles();
-      setSelectedProfileId(undefined);
-    }
-  }, [open, clearProfiles]);
+  const handleClose = () => {
+    clearProfiles();
+    setSelectedProfileId(undefined);
+    onClose();
+  };
 
   const handleTemplateChange = (templateId: string) => {
     fetchProfiles(templateId);
@@ -65,31 +58,31 @@ export function CreateDeviceModal({ open, onClose }: CreateDeviceModalProps) {
 
   const handleSingleSubmit = async () => {
     const values = await singleForm.validateFields();
-    if (selectedProfileId === "__none__") {
+    if (effectiveProfileId === "__none__") {
       values.profile_id = null;
-    } else if (selectedProfileId) {
-      values.profile_id = selectedProfileId;
+    } else if (effectiveProfileId) {
+      values.profile_id = effectiveProfileId;
     }
     const result = await createDevice(values);
     if (result) {
       singleForm.resetFields();
       await fetchDevices();
-      onClose();
+      handleClose();
     }
   };
 
   const handleBatchSubmit = async () => {
     const values = await batchForm.validateFields();
-    if (selectedProfileId === "__none__") {
+    if (effectiveProfileId === "__none__") {
       values.profile_id = null;
-    } else if (selectedProfileId) {
-      values.profile_id = selectedProfileId;
+    } else if (effectiveProfileId) {
+      values.profile_id = effectiveProfileId;
     }
     const success = await batchCreateDevices(values);
     if (success) {
       batchForm.resetFields();
       await fetchDevices();
-      onClose();
+      handleClose();
     }
   };
 
@@ -105,7 +98,7 @@ export function CreateDeviceModal({ open, onClose }: CreateDeviceModalProps) {
     <Form.Item label="Simulation Profile">
       <Select
         options={profileOptions}
-        value={selectedProfileId ?? undefined}
+        value={effectiveProfileId}
         onChange={(v) => setSelectedProfileId(v)}
         placeholder={
           profilesLoading ? "Loading profiles..." : "Select profile"
@@ -122,7 +115,7 @@ export function CreateDeviceModal({ open, onClose }: CreateDeviceModalProps) {
       title="Create Device"
       open={open}
       onOk={handleOk}
-      onCancel={onClose}
+      onCancel={handleClose}
       destroyOnClose
     >
       <Tabs

--- a/frontend/src/pages/Devices/DeviceDetail.tsx
+++ b/frontend/src/pages/Devices/DeviceDetail.tsx
@@ -77,15 +77,16 @@ export default function DeviceDetail() {
 
   const { connected } = useWebSocket({ url: MONITOR_WS_URL, onMessage });
 
+  const deviceRegisters = currentDevice?.registers;
   const registersWithLiveValues = useMemo(() => {
-    if (!currentDevice?.registers) return [];
-    if (liveRegisters.length === 0) return currentDevice.registers;
+    if (!deviceRegisters) return [];
+    if (liveRegisters.length === 0) return deviceRegisters;
     const liveMap = new Map(liveRegisters.map((r) => [r.name, r.value]));
-    return currentDevice.registers.map((reg) => ({
+    return deviceRegisters.map((reg) => ({
       ...reg,
       value: liveMap.get(reg.name) ?? reg.value,
     }));
-  }, [currentDevice?.registers, liveRegisters]);
+  }, [deviceRegisters, liveRegisters]);
 
   const handleInlineUpdate = async (field: "name" | "description", value: string) => {
     if (!currentDevice || !id) return;

--- a/frontend/src/pages/Devices/MqttPublishConfig.tsx
+++ b/frontend/src/pages/Devices/MqttPublishConfig.tsx
@@ -14,7 +14,7 @@ import {
   Typography,
   message,
 } from "antd";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { mqttApi } from "../../services/mqttApi";
 import type { MqttPublishConfig as MqttConfig, MqttPublishConfigWrite } from "../../types/mqtt";
 
@@ -29,16 +29,20 @@ export function MqttPublishConfig({ deviceId, onPublishStateChange }: MqttPublis
   const [loading, setLoading] = useState(false);
   const [actionLoading, setActionLoading] = useState(false);
 
+  // Keep the latest callback without retriggering the load effect.
+  const onPublishStateChangeRef = useRef(onPublishStateChange);
   useEffect(() => {
-    loadConfig();
-  }, [deviceId]);
+    onPublishStateChangeRef.current = onPublishStateChange;
+  }, [onPublishStateChange]);
 
-  const loadConfig = async () => {
-    try {
-      const resp = await mqttApi.getDeviceConfig(deviceId);
-      if (resp.data) {
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await mqttApi.getDeviceConfig(deviceId);
+        if (cancelled || !resp.data) return;
         setConfig(resp.data);
-        onPublishStateChange?.(resp.data.enabled);
+        onPublishStateChangeRef.current?.(resp.data.enabled);
         form.setFieldsValue({
           topic_template: resp.data.topic_template,
           payload_mode: resp.data.payload_mode,
@@ -46,11 +50,14 @@ export function MqttPublishConfig({ deviceId, onPublishStateChange }: MqttPublis
           qos: resp.data.qos,
           retain: resp.data.retain,
         });
+      } catch {
+        // No config yet
       }
-    } catch {
-      // No config yet
-    }
-  };
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deviceId, form]);
 
   const updateConfig = (newConfig: MqttConfig) => {
     setConfig(newConfig);

--- a/frontend/src/pages/Settings/MqttBrokerSettings.tsx
+++ b/frontend/src/pages/Settings/MqttBrokerSettings.tsx
@@ -19,19 +19,21 @@ export function MqttBrokerSettings() {
   const [testing, setTesting] = useState(false);
 
   useEffect(() => {
-    loadSettings();
-  }, []);
-
-  const loadSettings = async () => {
-    try {
-      const resp = await mqttApi.getBrokerSettings();
-      if (resp.data) {
-        form.setFieldsValue(resp.data);
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await mqttApi.getBrokerSettings();
+        if (!cancelled && resp.data) {
+          form.setFieldsValue(resp.data);
+        }
+      } catch {
+        // Use defaults
       }
-    } catch {
-      // Use defaults
-    }
-  };
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [form]);
 
   const handleSave = async () => {
     setLoading(true);

--- a/frontend/src/pages/Simulation/AnomalyTab.tsx
+++ b/frontend/src/pages/Simulation/AnomalyTab.tsx
@@ -10,7 +10,7 @@ import {
   message,
 } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { ANOMALY_PARAM_FIELDS, ANOMALY_TYPE_OPTIONS } from "../../constants/anomaly";
 import { deviceApi } from "../../services/deviceApi";
 import { useSimulationStore } from "../../stores/simulationStore";
@@ -37,20 +37,26 @@ export function AnomalyTab({ deviceId }: { deviceId: string }) {
   const [selectedType, setSelectedType] = useState<AnomalyType | null>(null);
   const [form] = Form.useForm();
 
-  const loadRegisters = useCallback(async () => {
-    try {
-      const response = await deviceApi.get(deviceId);
-      setRegisters(response.data?.registers ?? []);
-    } catch {
-      message.error("Failed to load device registers");
-    }
-  }, [deviceId]);
-
   useEffect(() => {
-    loadRegisters();
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await deviceApi.get(deviceId);
+        if (!cancelled) {
+          setRegisters(response.data?.registers ?? []);
+        }
+      } catch {
+        if (!cancelled) {
+          message.error("Failed to load device registers");
+        }
+      }
+    })();
     fetchActiveAnomalies(deviceId);
     fetchSchedules(deviceId);
-  }, [deviceId, loadRegisters, fetchActiveAnomalies, fetchSchedules]);
+    return () => {
+      cancelled = true;
+    };
+  }, [deviceId, fetchActiveAnomalies, fetchSchedules]);
 
   const registerOptions = registers.map((r) => ({
     value: r.name,

--- a/frontend/src/pages/Simulation/DataModeTab.tsx
+++ b/frontend/src/pages/Simulation/DataModeTab.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, InputNumber, Select, Switch, Table, message } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { deviceApi } from "../../services/deviceApi";
 import { useSimulationStore } from "../../stores/simulationStore";
 import type { RegisterValue, SimulationConfigRequest } from "../../types";
@@ -26,29 +26,32 @@ interface ConfigRow {
 export function DataModeTab({ deviceId }: { deviceId: string }) {
   const { configs, loading, fetchConfigs, saveConfigs } = useSimulationStore();
   const [registers, setRegisters] = useState<RegisterValue[]>([]);
-  const [rows, setRows] = useState<ConfigRow[]>([]);
-
-  const loadRegisters = useCallback(async () => {
-    try {
-      const response = await deviceApi.get(deviceId);
-      setRegisters(response.data?.registers ?? []);
-    } catch {
-      message.error("Failed to load device registers");
-    }
-  }, [deviceId]);
+  // User edits overlaid on the server-derived base rows, keyed by register name.
+  const [edits, setEdits] = useState<Record<string, Partial<ConfigRow>>>({});
 
   useEffect(() => {
-    loadRegisters();
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await deviceApi.get(deviceId);
+        if (!cancelled) {
+          setRegisters(response.data?.registers ?? []);
+        }
+      } catch {
+        if (!cancelled) {
+          message.error("Failed to load device registers");
+        }
+      }
+    })();
     fetchConfigs(deviceId);
-  }, [deviceId, loadRegisters, fetchConfigs]);
+    return () => {
+      cancelled = true;
+    };
+  }, [deviceId, fetchConfigs]);
 
-  // Build rows when registers or configs change
-  useEffect(() => {
-    if (registers.length === 0) return;
-
+  const rows: ConfigRow[] = useMemo(() => {
     const configMap = new Map(configs.map((c) => [c.register_name, c]));
-
-    const newRows: ConfigRow[] = registers.map((reg) => {
+    return registers.map((reg) => {
       const existing = configMap.get(reg.name);
       return {
         key: reg.name,
@@ -58,15 +61,13 @@ export function DataModeTab({ deviceId }: { deviceId: string }) {
         mode_params: existing ? JSON.stringify(existing.mode_params, null, 2) : "{}",
         is_enabled: existing?.is_enabled ?? false,
         update_interval_ms: existing?.update_interval_ms ?? 1000,
+        ...edits[reg.name],
       };
     });
-    setRows(newRows);
-  }, [registers, configs]);
+  }, [registers, configs, edits]);
 
   const updateRow = (key: string, field: keyof ConfigRow, value: unknown) => {
-    setRows((prev) =>
-      prev.map((r) => (r.key === key ? { ...r, [field]: value } : r)),
-    );
+    setEdits((prev) => ({ ...prev, [key]: { ...prev[key], [field]: value } }));
   };
 
   const handleSave = async () => {
@@ -87,7 +88,11 @@ export function DataModeTab({ deviceId }: { deviceId: string }) {
         update_interval_ms: row.update_interval_ms,
       });
     }
-    await saveConfigs(deviceId, { configs: configRequests });
+    const success = await saveConfigs(deviceId, { configs: configRequests });
+    if (success) {
+      // Saved values are now in the store-backed base rows; drop the overlay.
+      setEdits({});
+    }
   };
 
   const columns: ColumnsType<ConfigRow> = [

--- a/frontend/src/pages/Templates/ImportExportButtons.tsx
+++ b/frontend/src/pages/Templates/ImportExportButtons.tsx
@@ -104,13 +104,3 @@ export function ImportExportButtons() {
     </Upload>
   );
 }
-
-export async function handleExport(templateId: string, templateName: string) {
-  const blob = await templateApi.exportTemplate(templateId);
-  const url = window.URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `${templateName.replace(/\s+/g, "_").toLowerCase()}.json`;
-  a.click();
-  window.URL.revokeObjectURL(url);
-}

--- a/frontend/src/pages/Templates/ProfileFormModal.tsx
+++ b/frontend/src/pages/Templates/ProfileFormModal.tsx
@@ -9,7 +9,7 @@ import {
   message,
 } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useProfileStore } from "../../stores/profileStore";
 import type {
   DataMode,
@@ -53,11 +53,13 @@ export function ProfileFormModal({
   const [form] = Form.useForm();
   const { createProfile, updateProfile, fetchProfiles, loading } =
     useProfileStore();
-  const [rows, setRows] = useState<ConfigRow[]>([]);
+  // User edits overlaid on the profile-derived base rows, keyed by register name.
+  const [edits, setEdits] = useState<Record<string, Partial<ConfigRow>>>({});
 
   const isEdit = Boolean(profile);
   const isBuiltinConfigs = Boolean(profile?.is_builtin);
 
+  // Sync the antd form (an external store) with the profile being edited.
   useEffect(() => {
     if (!open) return;
 
@@ -69,13 +71,13 @@ export function ProfileFormModal({
     } else {
       form.resetFields();
     }
+  }, [open, profile, form]);
 
-    // Build config rows from template registers
+  const rows: ConfigRow[] = useMemo(() => {
     const configMap = new Map(
       (profile?.configs ?? []).map((c) => [c.register_name, c]),
     );
-
-    const newRows: ConfigRow[] = registers.map((reg) => {
+    return registers.map((reg) => {
       const existing = configMap.get(reg.name);
       return {
         key: reg.name,
@@ -86,15 +88,18 @@ export function ProfileFormModal({
           : "{}",
         is_enabled: existing?.is_enabled ?? true,
         update_interval_ms: existing?.update_interval_ms ?? 1000,
+        ...edits[reg.name],
       };
     });
-    setRows(newRows);
-  }, [open, profile, registers, form]);
+  }, [profile, registers, edits]);
 
   const updateRow = (key: string, field: keyof ConfigRow, value: unknown) => {
-    setRows((prev) =>
-      prev.map((r) => (r.key === key ? { ...r, [field]: value } : r)),
-    );
+    setEdits((prev) => ({ ...prev, [key]: { ...prev[key], [field]: value } }));
+  };
+
+  const handleClose = () => {
+    setEdits({});
+    onClose();
   };
 
   const handleSubmit = async () => {
@@ -138,7 +143,7 @@ export function ProfileFormModal({
 
     if (success) {
       await fetchProfiles(templateId);
-      onClose();
+      handleClose();
     }
   };
 
@@ -217,7 +222,7 @@ export function ProfileFormModal({
       title={isEdit ? "Edit Profile" : "New Profile"}
       open={open}
       onOk={handleSubmit}
-      onCancel={onClose}
+      onCancel={handleClose}
       width={900}
       destroyOnClose
       confirmLoading={loading}

--- a/frontend/src/pages/Templates/TemplateForm.tsx
+++ b/frontend/src/pages/Templates/TemplateForm.tsx
@@ -34,24 +34,30 @@ export default function TemplateForm() {
   );
 
   useEffect(() => {
+    let cancelled = false;
     if (id) {
-      fetchTemplate(id);
+      (async () => {
+        const template = await fetchTemplate(id);
+        if (cancelled || !template) return;
+        form.setFieldsValue({
+          name: template.name,
+          protocol: template.protocol,
+          description: template.description,
+        });
+        setRegisters(
+          template.registers.map((reg) => {
+            const rest = { ...reg };
+            delete rest.id;
+            return rest;
+          })
+        );
+      })();
     }
-    return () => clearCurrentTemplate();
-  }, [id, fetchTemplate, clearCurrentTemplate]);
-
-  useEffect(() => {
-    if (currentTemplate && isEdit) {
-      form.setFieldsValue({
-        name: currentTemplate.name,
-        protocol: currentTemplate.protocol,
-        description: currentTemplate.description,
-      });
-      setRegisters(
-        currentTemplate.registers.map(({ id: _id, ...rest }) => rest)
-      );
-    }
-  }, [currentTemplate, isEdit, form]);
+    return () => {
+      cancelled = true;
+      clearCurrentTemplate();
+    };
+  }, [id, fetchTemplate, clearCurrentTemplate, form]);
 
   const handleSubmit = async () => {
     const values = await form.validateFields();

--- a/frontend/src/pages/Templates/TemplateList.tsx
+++ b/frontend/src/pages/Templates/TemplateList.tsx
@@ -12,7 +12,8 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import type { TemplateSummary } from "../../types";
 import { useTemplateStore } from "../../stores/templateStore";
-import { handleExport, ImportExportButtons } from "./ImportExportButtons";
+import { ImportExportButtons } from "./ImportExportButtons";
+import { exportTemplate } from "./exportTemplate";
 
 export function TemplateList() {
   const navigate = useNavigate();
@@ -103,7 +104,7 @@ export function TemplateList() {
               type="text"
               size="small"
               icon={<ExportOutlined />}
-              onClick={() => handleExport(record.id, record.name)}
+              onClick={() => exportTemplate(record.id, record.name)}
             />
           </Tooltip>
           {!record.is_builtin && (

--- a/frontend/src/pages/Templates/exportTemplate.ts
+++ b/frontend/src/pages/Templates/exportTemplate.ts
@@ -1,0 +1,11 @@
+import { templateApi } from "../../services/templateApi";
+
+export async function exportTemplate(templateId: string, templateName: string) {
+  const blob = await templateApi.exportTemplate(templateId);
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${templateName.replace(/\s+/g, "_").toLowerCase()}.json`;
+  a.click();
+  window.URL.revokeObjectURL(url);
+}

--- a/frontend/src/stores/templateStore.ts
+++ b/frontend/src/stores/templateStore.ts
@@ -14,7 +14,7 @@ interface TemplateState {
   currentTemplate: TemplateDetail | null;
   loading: boolean;
   fetchTemplates: () => Promise<void>;
-  fetchTemplate: (id: string) => Promise<void>;
+  fetchTemplate: (id: string) => Promise<TemplateDetail | null>;
   createTemplate: (data: CreateTemplate) => Promise<TemplateDetail | null>;
   updateTemplate: (
     id: string,
@@ -48,6 +48,7 @@ export const useTemplateStore = create<TemplateState>((set) => ({
     try {
       const response = await templateApi.get(id);
       set({ currentTemplate: response.data });
+      return response.data;
     } finally {
       set({ loading: false });
     }

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -35,7 +35,7 @@ export interface CreateTemplate {
   registers: Omit<RegisterDefinition, "id">[];
 }
 
-export interface UpdateTemplate extends CreateTemplate {}
+export type UpdateTemplate = CreateTemplate;
 
 export interface TemplateClone {
   new_name?: string;


### PR DESCRIPTION
Closes #63

## 重點修復

### `useWebSocket` 重寫(唯一的真 bug 風險)
- 原本 `connect` useCallback 在自己的 reconnect closure 裡自我引用(declaration-order error + stale-closure 風險),且 `onMessage` 在 deps 裡——**callback identity 一變就整顆 socket 斷線重連**
- 改成:連線生命週期收進單一 effect(local function hoist 可安全自我引用)、`onMessage` 走 ref(handler 更新不再觸發重連)、`disposed` flag 防 unmount 後 timer 重連
- 對外 API 不變(`{ connected }`)

### 六處 setState-in-effect → derived state
| 檔案 | 做法 |
|---|---|
| DataModeTab / ProfileFormModal | rows = `useMemo` server-derived base + user-edit overlay,存檔/關閉清 overlay |
| CreateDeviceModal ×2 | default profile 改 render 期 derive,關閉清理移到 `handleClose` 事件 |
| TemplateForm | `fetchTemplate` 改回傳資料,初始化收進 async effect(順帶消掉 `_id` unused) |
| AnomalyTab / DataModeTab | register fetch 內聯 async IIFE + cancelled flag |

### 其他
- `UpdateTemplate` 空 interface → type alias
- `handleExport` 搬出 component 檔成 `exportTemplate.ts`(react-refresh 規則)
- DeviceDetail `useMemo` deps 抽出 optional chain(React Compiler memoization)
- Mqtt 兩處 exhaustive-deps warning 修正

## 驗證

- `npm run lint` → **0 error 0 warning**(原 12 errors / 2 warnings)
- `npm run build` 通過
- **WS 重連 e2e 實測**(Playwright + 本機 dev compose):Monitor 顯示 Live → `docker compose stop backend` → Disconnected → `start backend` → **自動恢復 Live,無需重整**(issue 驗收條件)
- TemplateForm 編輯頁實測:名稱/registers 正確載入
- DataModeTab 實測:改 interval 只動該 row → Save All → server 回讀正確 → overlay 清空(測完已還原資料)

## 備註

與 PR #69(deps lock)平行開發,兩邊都改 CHANGELOG/dev-log 開頭,後 merge 的那個會需要解一次小衝突(我可以處理)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)