### PR TITLE
chore: cut release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-06-22
+
 ### Documentation
 - Deployment guide: new "team member access" coverage — add teammate emails to the Cloudflare Access policy for Web UI/API, and share the Linode via **Tailscale node sharing** (single-machine share, no tailnet membership needed) for the protocol ports (Modbus 502 / OPC UA 4840 / SNMP 161), including Windows client setup and connectivity checks.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Multi-protocol device simulator for energy management systems.
 
-[![Version](https://img.shields.io/badge/version-0.4.2-blue)]()
+[![Version](https://img.shields.io/badge/version-0.4.3-blue)]()
 [![Python](https://img.shields.io/badge/python-3.12+-blue)]()
 [![License](https://img.shields.io/badge/license-MIT-green)]()
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
 
     # App
     APP_NAME: str = "GhostMeter"
-    APP_VERSION: str = "0.4.2"
+    APP_VERSION: str = "0.4.3"
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
 

--- a/docs/development-phases.md
+++ b/docs/development-phases.md
@@ -291,6 +291,8 @@
 - [x] **v0.4.0 released** (2026-06-11): PRs #47/#48/#49 merged with CI green, `v0.4.0` tag + GitHub Release published
 - [x] Deferred /simplify findings resolved per Ken's rulings: **PR #50** (negative max_drift seed bug — sign flip at the clamp — fixed + Alembic data repair + unified `AnomalyParamsBase` validation across inject/schedule/scenario) and **PR #51** (OPC UA delay fault moved to async PreRead hook — no longer blocks the event loop; red-test verified)
 - [x] **v0.4.1 released** (2026-06-11): the two fixes above
+- [x] **v0.4.2 released** (2026-06-11): builtin scenarios never seeded (seed template-name mismatch + WARN-only loader) fixed with guard tests; `.env.example` stale `APP_VERSION=0.1.0` pin removed
+- [x] **v0.4.3 released** (2026-06-22): opt-in Cloudflare Tunnel sidecar (PR #59); Monitor WebSocket same-origin (PR #58); fake header "Live" badge removed (PR #68); backend deps fully locked + dev/prod split, pytest out of prod image (PR #69, issue #60); 14 ESLint problems fixed incl. `useWebSocket` reconnect rewrite (PR #73, issue #63); team-member access deploy guide (PR #70)
 - [ ] Remaining follow-ups (no decision needed): monitor_service per-tick DB query caching, per-adapter fault decision trees → shared resolver, MQTT-specific monitor payload fields → generic adapter_status, monitorStore singleton WS connection
 - [ ] Address issues surfaced during audit: #21 (Cloudflare Pages build config), #22 (npm audit vulnerabilities), #23 (frontend bundle >500KB)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "antd": "^6.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump 0.4.2 → 0.4.3 and CHANGELOG/phases doc finalization. No behavior change — release packaging only.

## What's in 0.4.3 (since 0.4.2)
- **Cloudflare Tunnel** opt-in sidecar for deploy hosts (#59)
- **Monitor WebSocket same-origin** — works behind reverse proxy / HTTPS tunnel (#58)
- **Removed fake "Live" badge** from app header (#68)
- **Backend dependencies fully locked** + dev/prod split — pytest out of prod image (#69, closes #60)
- **14 ESLint problems fixed** incl. `useWebSocket` reconnect rewrite (#73, closes #63)
- **Team-member access deploy guide** (#70)

## Version refs bumped
- `backend/app/config.py` APP_VERSION
- `frontend/package.json` + `package-lock.json`
- README version badge

## Docs
- CHANGELOG `[Unreleased]` → `[0.4.3] - 2026-06-22`
- development-phases.md Milestone 8.7 release history

🤖 Generated with [Claude Code](https://claude.com/claude-code)